### PR TITLE
Add Today Page with Reusable Task Components and Overdue Section

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,5 +1,6 @@
 import CategoryComponent from '@components/Category';
 import UserMenu from '@components/UserMenu';
+import { useCountTask } from '@hooks/useTask';
 import { Box, List, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import { NavLink } from 'react-router';
 import { navItems } from 'src/constants/navItems';
@@ -9,6 +10,7 @@ type SidebarProps = {
   isMobile: boolean;
 };
 function Sidebar({ handleClose, isMobile }: SidebarProps) {
+  const { data: taskCount } = useCountTask();
   return (
     <>
       <Box sx={{ height: '100%', width: '100%' }}>
@@ -30,7 +32,13 @@ function Sidebar({ handleClose, isMobile }: SidebarProps) {
               }}
             >
               <ListItemIcon>{item.icon}</ListItemIcon>
-              <ListItemText primary={item.label} />
+              <ListItemText
+                primary={
+                  item.showCount && taskCount?.[item.key] > 0
+                    ? `${item.label} (${taskCount[item.key]})`
+                    : item.label
+                }
+              />
             </ListItemButton>
           ))}
           <CategoryComponent />

--- a/src/components/Task/OverdueSection.tsx
+++ b/src/components/Task/OverdueSection.tsx
@@ -1,22 +1,22 @@
-import type { ITask, SelectedTaskForm } from '@app-types/task';
-import { Box, IconButton, List, Stack, Typography } from '@mui/material';
+import type { ITask, TaskFormValues } from '@app-types/task';
+import { Box, IconButton, Stack, Typography } from '@mui/material';
 import { useState } from 'react';
-import TaskItem from '.';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
+import TaskListController from './TaskListController';
 
 type Props = {
-  tasks: ITask[] | undefined;
-  handleEdit: (data: SelectedTaskForm) => void;
+  overdueTasks: ITask[] | undefined;
+  defaultFormValues: TaskFormValues;
 };
 
-export default function OverdueTask({ tasks, handleEdit }: Props) {
+export default function OverdueSection({ overdueTasks, defaultFormValues }: Props) {
   const [expanded, setExpanded] = useState(false);
 
   return (
     <Box sx={{ mt: 2 }}>
       <Stack direction="row" alignItems={'center'} sx={{ borderBottom: '1px solid #eee' }}>
         <Typography variant="subtitle2" fontWeight="bold" color="primary">
-          Overdue ({tasks?.length})
+          Overdue ({overdueTasks?.length})
         </Typography>
         <IconButton
           onClick={() => setExpanded((prev) => !prev)}
@@ -27,11 +27,12 @@ export default function OverdueTask({ tasks, handleEdit }: Props) {
       </Stack>
 
       {expanded && (
-        <List component="div" sx={{ p: 0 }}>
-          {tasks?.map((task) => (
-            <TaskItem key={task.id} task={task} onEdit={handleEdit} />
-          ))}
-        </List>
+        <TaskListController
+          tasks={overdueTasks}
+          defaultFormValues={defaultFormValues}
+          allowAdd={false}
+          showDueDate={true}
+        />
       )}
     </Box>
   );

--- a/src/components/Task/OverdueTask.tsx
+++ b/src/components/Task/OverdueTask.tsx
@@ -1,0 +1,38 @@
+import type { ITask, SelectedTaskForm } from '@app-types/task';
+import { Box, IconButton, List, Stack, Typography } from '@mui/material';
+import { useState } from 'react';
+import TaskItem from '.';
+import { ExpandLess, ExpandMore } from '@mui/icons-material';
+
+type Props = {
+  tasks: ITask[] | undefined;
+  handleEdit: (data: SelectedTaskForm) => void;
+};
+
+export default function OverdueTask({ tasks, handleEdit }: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Stack direction="row" alignItems={'center'} sx={{ borderBottom: '1px solid #eee' }}>
+        <Typography variant="subtitle2" fontWeight="bold" color="primary">
+          Overdue ({tasks?.length})
+        </Typography>
+        <IconButton
+          onClick={() => setExpanded((prev) => !prev)}
+          sx={{ color: 'primary.main', fontWeight: 'bold' }}
+        >
+          {expanded ? <ExpandLess /> : <ExpandMore />}
+        </IconButton>
+      </Stack>
+
+      {expanded && (
+        <List component="div" sx={{ p: 0 }}>
+          {tasks?.map((task) => (
+            <TaskItem key={task.id} task={task} onEdit={handleEdit} />
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+}

--- a/src/components/Task/TaskEditor.tsx
+++ b/src/components/Task/TaskEditor.tsx
@@ -20,29 +20,27 @@ import { useEffect, useState } from 'react';
 import { PRIORITY_META, PriorityLevel } from '@app-types/enum';
 
 type TaskEditorProps = {
+  defaultFormValues: TaskFormValues;
   initialData?: SelectedTaskForm;
   onClose: () => void;
   onSubmit: (data: TaskRequest) => void;
   isPending?: boolean;
 };
 
-function TaskEditor({ initialData, onClose, onSubmit, isPending }: TaskEditorProps) {
-  const initialValues = {
-    title: '',
-    description: '',
-    dueDate: null,
-    priority: PriorityLevel.LOW,
-  };
-
+function TaskEditor({
+  defaultFormValues,
+  initialData,
+  onClose,
+  onSubmit,
+  isPending,
+}: TaskEditorProps) {
   const { control, handleSubmit, watch, reset } = useForm<TaskFormValues>({
-    defaultValues: initialValues,
+    defaultValues: defaultFormValues,
   });
 
   useEffect(() => {
     if (initialData) {
       reset({ ...initialData });
-    } else {
-      reset(initialValues);
     }
   }, [initialData]);
 

--- a/src/components/Task/TaskEditor.tsx
+++ b/src/components/Task/TaskEditor.tsx
@@ -70,7 +70,6 @@ function TaskEditor({
       <Paper
         elevation={3}
         sx={{
-          position: 'absolute',
           width: '100%',
           maxWidth: '800px',
           bgcolor: 'background.default',

--- a/src/components/Task/TaskListController.tsx
+++ b/src/components/Task/TaskListController.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import type { TaskRequest, SelectedTaskForm, ITask, TaskFormValues } from '@app-types/task';
+import { useAddTask, useUpdateTask } from '@hooks/useTask';
+import TaskListSection from './TaskListSection';
+
+type Props = {
+  tasks?: ITask[];
+  title?: string;
+  defaultFormValues: TaskFormValues;
+  allowAdd?: boolean;
+  showDueDate?: boolean;
+};
+
+export default function TaskListController({
+  tasks,
+  title,
+  defaultFormValues,
+  allowAdd = true,
+  showDueDate,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<SelectedTaskForm | undefined>();
+
+  const { mutateAsync: addTask, isPending: isPendingAdd } = useAddTask();
+  const { mutateAsync: updateTask, isPending: isPendingUpdate } = useUpdateTask();
+
+  const handleSubmit = async (data: TaskRequest) => {
+    try {
+      if (selectedTask) {
+        await updateTask({ id: selectedTask.id, task: data });
+        setSelectedTask(undefined);
+      } else {
+        await addTask(data);
+      }
+    } catch (e) {
+      console.error('Error:', e);
+    }
+  };
+
+  const handleEdit = (task: SelectedTaskForm) => {
+    setSelectedTask(task);
+    setOpen(true);
+  };
+
+  const handleAddNew = () => {
+    setSelectedTask(undefined);
+    setOpen(true);
+  };
+
+  const handleCloseEditor = () => {
+    setSelectedTask(undefined);
+    setOpen(false);
+  };
+
+  return (
+    <TaskListSection
+      tasks={tasks}
+      title={title}
+      defaultFormValues={defaultFormValues}
+      selectedTask={selectedTask}
+      open={open}
+      onEdit={handleEdit}
+      onAddNew={handleAddNew}
+      onCloseEditor={handleCloseEditor}
+      onSubmit={handleSubmit}
+      isPendingAdd={isPendingAdd}
+      isPendingUpdate={isPendingUpdate}
+      allowAdd={allowAdd}
+      showDueDate={showDueDate}
+    />
+  );
+}

--- a/src/components/Task/TaskListSection.tsx
+++ b/src/components/Task/TaskListSection.tsx
@@ -1,0 +1,93 @@
+import { Add } from '@mui/icons-material';
+import { Box, List, Stack, Typography, IconButton } from '@mui/material';
+import TaskEditor from './TaskEditor';
+import type { ITask, SelectedTaskForm, TaskFormValues, TaskRequest } from '@app-types/task';
+import TaskItem from '.';
+
+type TaskListSectionProps = {
+  tasks?: ITask[];
+  title?: string;
+  defaultFormValues: TaskFormValues;
+  selectedTask?: SelectedTaskForm;
+  open: boolean;
+  onSubmit: (data: TaskRequest) => Promise<void>;
+  isPendingAdd: boolean;
+  isPendingUpdate: boolean;
+  onEdit: (task: SelectedTaskForm) => void;
+  onAddNew: () => void;
+  onCloseEditor: () => void;
+  allowAdd?: boolean;
+  showDueDate?: boolean;
+};
+
+export default function TaskListSection({
+  tasks,
+  title,
+  defaultFormValues,
+  selectedTask,
+  open,
+  onSubmit,
+  isPendingAdd,
+  isPendingUpdate,
+  onEdit,
+  onAddNew,
+  onCloseEditor,
+  allowAdd,
+  showDueDate,
+}: TaskListSectionProps) {
+  return (
+    <Box>
+      {title && (
+        <Typography variant="subtitle2" fontWeight="bold" color="primary" mt={2}>
+          {title}
+        </Typography>
+      )}
+
+      <List disablePadding>
+        {tasks?.map((task) => (
+          <Box key={task.id}>
+            <TaskItem task={task} onEdit={onEdit} showDueDate={showDueDate} />
+            {selectedTask?.id === task.id && (
+              <Box mt={1} mb={2}>
+                <TaskEditor
+                  defaultFormValues={defaultFormValues}
+                  initialData={selectedTask}
+                  onClose={onCloseEditor}
+                  onSubmit={onSubmit}
+                  isPending={isPendingUpdate}
+                />
+              </Box>
+            )}
+          </Box>
+        ))}
+      </List>
+
+      {allowAdd && (
+        <>
+          <Stack direction="row" alignItems="center" mt={2}>
+            <IconButton size="small" onClick={onAddNew}>
+              <Add
+                sx={{
+                  color: 'primary.main',
+                  transform: { xs: 'scale(1.3)', md: 'scale(1)' },
+                }}
+              />
+            </IconButton>
+            <Typography sx={{ color: '#757575' }}>Add task</Typography>
+          </Stack>
+          {open && !selectedTask && (
+            <Box mt={-4} mb={4} position="absolute" width="100%">
+              <TaskEditor
+                defaultFormValues={defaultFormValues}
+                initialData={undefined}
+                onClose={onCloseEditor}
+                onSubmit={onSubmit}
+                isPending={isPendingAdd}
+              />
+            </Box>
+          )}
+        </>
+      )}
+    </Box>
+  );
+}

--- a/src/components/Task/index.tsx
+++ b/src/components/Task/index.tsx
@@ -6,7 +6,7 @@ import {
   EditOutlined,
   RadioButtonUnchecked,
 } from '@mui/icons-material';
-import { Box, Checkbox, Divider, IconButton, ListItem, Stack, Typography } from '@mui/material';
+import { Box, Checkbox, IconButton, ListItem, Stack, Typography } from '@mui/material';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useState } from 'react';
 import { PRIORITY_META } from '@app-types/enum';
@@ -66,7 +66,7 @@ function TaskItem({ task, onEdit }: TaskItemProps) {
               },
             }}
           >
-            <ListItem sx={{ py: 0.5, pl: 0 }}>
+            <ListItem sx={{ py: 0.5, pl: 0, borderBottom: '1px solid #eee' }}>
               <Checkbox
                 checked={checked}
                 onChange={handleChange}
@@ -154,7 +154,6 @@ function TaskItem({ task, onEdit }: TaskItemProps) {
                 </Stack>
               </Stack>
             </ListItem>
-            <Divider />
           </Box>
         </motion.div>
       )}

--- a/src/components/Task/index.tsx
+++ b/src/components/Task/index.tsx
@@ -4,6 +4,7 @@ import {
   CheckCircle,
   DeleteOutline,
   EditOutlined,
+  Event,
   RadioButtonUnchecked,
 } from '@mui/icons-material';
 import { Box, Checkbox, IconButton, ListItem, Stack, Typography } from '@mui/material';
@@ -14,18 +15,21 @@ import { useDeleteTask, usePatchTask } from '@hooks/useTask';
 import { enqueueSnackbar } from 'notistack';
 import { mapTaskToForm } from 'src/utils/task';
 import ConfirmDeleteDialog from './ConfirmDeleteDialog';
+import { format, isBefore, startOfToday } from 'date-fns';
 
 type TaskItemProps = {
   task: ITask;
   onEdit: (task: SelectedTaskForm) => void;
+  showDueDate?: boolean;
 };
 
-function TaskItem({ task, onEdit }: TaskItemProps) {
+function TaskItem({ task, onEdit, showDueDate }: TaskItemProps) {
   const [checked, setChecked] = useState(false);
   const [visible, setVisible] = useState(true);
   const [openDeleteConfirm, setOpenDeleteConfirm] = useState(false);
   const { mutateAsync } = usePatchTask();
   const { mutateAsync: mutateAsyncDelete } = useDeleteTask();
+  const isOverdue = task.dueDate && isBefore(new Date(task.dueDate), startOfToday());
 
   const handleChange = async () => {
     const completeRequest: PatchTaskRequest = {
@@ -121,6 +125,20 @@ function TaskItem({ task, onEdit }: TaskItemProps) {
                 <Stack spacing={0.2} justifyContent={'center'}>
                   <Typography>{task.title}</Typography>
                   <Typography variant="body2">{task.description}</Typography>
+                  {showDueDate && task.dueDate && (
+                    <Stack
+                      direction="row"
+                      spacing={0.5}
+                      alignItems="center"
+                      sx={{ color: isOverdue ? 'error.main' : '#9C27B0' }}
+                    >
+                      <Event sx={{ fontSize: '13px' }} />
+
+                      <Typography variant="caption">
+                        {format(new Date(task.dueDate), 'MMM dd')}
+                      </Typography>
+                    </Stack>
+                  )}
                 </Stack>
                 <Stack
                   direction="row"

--- a/src/constants/navItems.tsx
+++ b/src/constants/navItems.tsx
@@ -4,8 +4,20 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 
 export const navItems = [
-  { label: 'Inbox', icon: <InboxIcon />, to: '/inbox' },
-  { label: 'Today', icon: <TodayIcon />, to: '/today' },
-  { label: 'Upcoming', icon: <CalendarMonthIcon />, to: '/upcoming' },
-  { label: 'Completed', icon: <CheckCircleOutlineIcon />, to: '/completed' },
+  { label: 'Inbox', icon: <InboxIcon />, to: '/inbox', key: 'inbox', showCount: true },
+  { label: 'Today', icon: <TodayIcon />, to: '/today', key: 'today', showCount: true },
+  {
+    label: 'Upcoming',
+    icon: <CalendarMonthIcon />,
+    to: '/upcoming',
+    key: 'upcoming',
+    showCount: false,
+  },
+  {
+    label: 'Completed',
+    icon: <CheckCircleOutlineIcon />,
+    to: '/completed',
+    key: 'completed',
+    showCount: false,
+  },
 ];

--- a/src/hooks/useTask.ts
+++ b/src/hooks/useTask.ts
@@ -1,3 +1,4 @@
+import { PriorityLevel } from '@app-types/enum';
 import { taskAPI } from './../services/task';
 import type { GetTasksParams, ITask } from '@app-types/task';
 import { queryClient } from '@lib/queryClient';
@@ -69,4 +70,19 @@ export const useDeleteTask = () => {
       enqueueSnackbar('Faild to delete task', { variant: 'error' });
     },
   });
+};
+
+export const useTaskDefaults = (context: 'today' | 'inbox' | 'category', categoryId?: string) => {
+  const today = new Date();
+
+  switch (context) {
+    case 'inbox':
+      return { title: '', description: '', dueDate: null, priority: PriorityLevel.LOW };
+    case 'today':
+      return { title: '', description: '', dueDate: today, priority: PriorityLevel.LOW };
+    case 'category':
+      return { title: '', description: '', dueDate: null, priority: PriorityLevel.LOW, categoryId };
+    default:
+      return { title: '', description: '', dueDate: null, priority: PriorityLevel.LOW };
+  }
 };

--- a/src/hooks/useTask.ts
+++ b/src/hooks/useTask.ts
@@ -11,12 +11,19 @@ export const useTasks = (params: GetTasksParams) => {
   });
 };
 
+export const useCountTask = () => {
+  return useQuery({
+    queryKey: ['taskCount'],
+    queryFn: taskAPI.countTask,
+  });
+};
+
 export const useAddTask = () => {
   return useMutation({
-    mutationKey: ['add-task'],
+    mutationKey: ['addTask'],
     mutationFn: taskAPI.createTask,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tasks'] });
+      ['tasks', 'taskCount'].forEach((key) => queryClient.invalidateQueries({ queryKey: [key] }));
       enqueueSnackbar('Task added!', { variant: 'success' });
     },
     onError: () => {
@@ -27,10 +34,10 @@ export const useAddTask = () => {
 
 export const usePatchTask = () => {
   return useMutation({
-    mutationKey: ['patch-task'],
+    mutationKey: ['patchTask'],
     mutationFn: taskAPI.updatePartialTask,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tasks'] });
+      ['tasks', 'taskCount'].forEach((key) => queryClient.invalidateQueries({ queryKey: [key] }));
     },
     onError: () => {
       enqueueSnackbar('Faild to update task', { variant: 'error' });
@@ -40,10 +47,10 @@ export const usePatchTask = () => {
 
 export const useUpdateTask = () => {
   return useMutation({
-    mutationKey: ['update-task'],
+    mutationKey: ['updateTask'],
     mutationFn: taskAPI.updateTask,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tasks'] });
+      ['tasks', 'taskCount'].forEach((key) => queryClient.invalidateQueries({ queryKey: [key] }));
     },
     onError: () => {
       enqueueSnackbar('Faild to update task', { variant: 'error' });
@@ -53,10 +60,10 @@ export const useUpdateTask = () => {
 
 export const useDeleteTask = () => {
   return useMutation({
-    mutationKey: ['delete-task'],
+    mutationKey: ['deleteTask'],
     mutationFn: taskAPI.deleteTask,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tasks'] });
+      ['tasks', 'taskCount'].forEach((key) => queryClient.invalidateQueries({ queryKey: [key] }));
     },
     onError: () => {
       enqueueSnackbar('Faild to delete task', { variant: 'error' });

--- a/src/hooks/useTask.ts
+++ b/src/hooks/useTask.ts
@@ -72,7 +72,7 @@ export const useDeleteTask = () => {
   });
 };
 
-export const useTaskDefaults = (context: 'today' | 'inbox' | 'category', categoryId?: string) => {
+export const useTaskDefaults = (context?: 'today' | 'inbox' | 'category', categoryId?: string) => {
   const today = new Date();
 
   switch (context) {

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -16,7 +16,7 @@ export default function MainLayout() {
   }, [isMobile]);
 
   return (
-    <Box display="flex" height="100dvh" position="relative" overflow="hidden">
+    <Box display="flex" height="100dvh">
       <IconButton
         onClick={() => setOpen(!open)}
         sx={{
@@ -65,15 +65,15 @@ export default function MainLayout() {
       <Box
         component="main"
         sx={{
-          ml: 1,
-          width: !isMobile && open ? `calc(100vw - ${drawerWidth}px)` : '100dvw',
+          ml: !isMobile && open ? `${drawerWidth}px` : 0,
+          width: '100%',
           height: '100dvh',
-          transition: 'transform 0.3s',
-          transform: !isMobile && open ? `translateX(${drawerWidth}px)` : 'translateX(0)',
+          transition: 'margin-left 0.3s',
           display: 'flex',
           justifyContent: 'center',
           pt: 3,
           px: 2,
+          overflowX: 'hidden',
         }}
       >
         <Box sx={{ width: '100%', maxWidth: 800, mt: 6 }}>

--- a/src/pages/InboxPage.tsx
+++ b/src/pages/InboxPage.tsx
@@ -1,46 +1,10 @@
-import type { SelectedTaskForm, TaskRequest } from '@app-types/task';
-import TaskItem from '@components/Task';
-import TaskEditor from '@components/Task/TaskEditor';
-import { useAddTask, useTaskDefaults, useTasks, useUpdateTask } from '@hooks/useTask';
-import { Add } from '@mui/icons-material';
-import { Box, Container, IconButton, List, Stack, Typography } from '@mui/material';
-import { useState } from 'react';
+import TaskListController from '@components/Task/TaskListController';
+import { useTaskDefaults, useTasks } from '@hooks/useTask';
+import { Container, Typography } from '@mui/material';
 
 function InboxPage() {
   const { data: inboxTasks } = useTasks({ inbox: true });
   const defaultInboxValues = useTaskDefaults('inbox');
-  const [selectedTask, setSelectedTask] = useState<SelectedTaskForm | undefined>(undefined);
-  const [open, setOpen] = useState(false);
-  const { mutateAsync: mutateAsyncAdd, isPending: isPendingAdd } = useAddTask();
-  const { mutateAsync: mutateAsyncUpdate, isPending: isPendingUpdate } = useUpdateTask();
-
-  const handleSubmit = async (data: TaskRequest) => {
-    try {
-      if (selectedTask) {
-        const updateData = {
-          id: selectedTask.id,
-          task: data,
-        };
-        await mutateAsyncUpdate(updateData);
-        setOpen(false);
-      } else {
-        await mutateAsyncAdd(data);
-      }
-    } catch (e) {
-      console.error('Error: ', e);
-    }
-  };
-
-  const handleAddTask = () => {
-    setSelectedTask(undefined);
-    setOpen(true);
-  };
-
-  const handleCloseEditor = () => setOpen(false);
-  const handleEdit = (data: SelectedTaskForm) => {
-    setOpen(true);
-    setSelectedTask(data);
-  };
 
   return (
     <div>
@@ -54,30 +18,11 @@ function InboxPage() {
         }}
       >
         <Typography variant="h1">Inbox</Typography>
-        <div>
-          <List component="div">
-            {inboxTasks?.map((task) => (
-              <TaskItem key={task.id} task={task} onEdit={handleEdit} />
-            ))}
-          </List>
-        </div>
-        <Stack direction="row" sx={{ alignItems: 'center' }}>
-          <IconButton size="small" sx={{ mb: 0.5 }} onClick={handleAddTask}>
-            <Add sx={{ color: 'primary.main', transform: { xs: 'scale(1.3)', md: 'scale(1)' } }} />
-          </IconButton>
-          <Typography sx={{ color: '#757575' }}>Add task</Typography>
-        </Stack>
-        <Box sx={{ mt: -4 }}>
-          {open && (
-            <TaskEditor
-              defaultFormValues={defaultInboxValues}
-              initialData={selectedTask}
-              onClose={() => handleCloseEditor()}
-              onSubmit={handleSubmit}
-              isPending={isPendingAdd || isPendingUpdate}
-            />
-          )}
-        </Box>
+        <TaskListController
+          tasks={inboxTasks}
+          defaultFormValues={defaultInboxValues}
+          showDueDate={true}
+        />
       </Container>
     </div>
   );

--- a/src/pages/InboxPage.tsx
+++ b/src/pages/InboxPage.tsx
@@ -1,13 +1,14 @@
 import type { SelectedTaskForm, TaskRequest } from '@app-types/task';
 import TaskItem from '@components/Task';
 import TaskEditor from '@components/Task/TaskEditor';
-import { useAddTask, useTasks, useUpdateTask } from '@hooks/useTask';
+import { useAddTask, useTaskDefaults, useTasks, useUpdateTask } from '@hooks/useTask';
 import { Add } from '@mui/icons-material';
 import { Box, Container, IconButton, List, Stack, Typography } from '@mui/material';
 import { useState } from 'react';
 
 function InboxPage() {
   const { data: inboxTasks } = useTasks({ inbox: true });
+  const defaultInboxValues = useTaskDefaults('inbox');
   const [selectedTask, setSelectedTask] = useState<SelectedTaskForm | undefined>(undefined);
   const [open, setOpen] = useState(false);
   const { mutateAsync: mutateAsyncAdd, isPending: isPendingAdd } = useAddTask();
@@ -69,6 +70,7 @@ function InboxPage() {
         <Box sx={{ mt: -4 }}>
           {open && (
             <TaskEditor
+              defaultFormValues={defaultInboxValues}
               initialData={selectedTask}
               onClose={() => handleCloseEditor()}
               onSubmit={handleSubmit}

--- a/src/pages/TodayPage.tsx
+++ b/src/pages/TodayPage.tsx
@@ -1,51 +1,15 @@
-import type { SelectedTaskForm, TaskRequest } from '@app-types/task';
-import TaskItem from '@components/Task';
-import OverdueTask from '@components/Task/OverdueTask';
-import TaskEditor from '@components/Task/TaskEditor';
-import { useAddTask, useTaskDefaults, useTasks, useUpdateTask } from '@hooks/useTask';
-import { Add } from '@mui/icons-material';
-import { Box, Container, IconButton, List, Stack, Typography } from '@mui/material';
+import { Container, Typography } from '@mui/material';
 import { format } from 'date-fns';
-import { useState } from 'react';
+import TaskListController from '@components/Task/TaskListController';
+import { useTaskDefaults, useTasks } from '@hooks/useTask';
+import OverdueSection from '@components/Task/OverdueSection';
 
 function TodayPage() {
   const todayStr = format(new Date(), 'yyyy-MM-dd');
   const { data: todayTasks } = useTasks({ dueDate: todayStr });
   const { data: overdueTasks } = useTasks({ status: 'overdue' });
   const defaultTodayValues = useTaskDefaults('today');
-  const [open, setOpen] = useState(false);
-  const [selectedTask, setSelectedTask] = useState<SelectedTaskForm | undefined>(undefined);
-
-  const { mutateAsync: mutateAsyncAdd, isPending: isPendingAdd } = useAddTask();
-  const { mutateAsync: mutateAsyncUpdate, isPending: isPendingUpdate } = useUpdateTask();
-
-  const handleSubmit = async (data: TaskRequest) => {
-    try {
-      if (selectedTask) {
-        await mutateAsyncUpdate({ id: selectedTask.id, task: data });
-        setSelectedTask(undefined);
-      } else {
-        await mutateAsyncAdd(data);
-      }
-    } catch (e) {
-      console.error('Error: ', e);
-    }
-  };
-
-  const handleAddTask = () => {
-    setOpen(true);
-    setSelectedTask(undefined);
-  };
-
-  const handleCloseEditor = () => {
-    setOpen(false);
-    setSelectedTask(undefined);
-  };
-
-  const handleEdit = (task: SelectedTaskForm) => {
-    setOpen(true);
-    setSelectedTask(task);
-  };
+  const defaultValues = useTaskDefaults();
 
   return (
     <Container
@@ -59,57 +23,15 @@ function TodayPage() {
       }}
     >
       <Typography variant="h1">Today</Typography>
-
-      <OverdueTask tasks={overdueTasks} handleEdit={handleEdit} />
-
-      <Box sx={{ mt: 4 }}>
-        <Typography variant="subtitle2" fontWeight="bold" color="primary">
-          Tasks for Today
-        </Typography>
-
-        <List component="div" disablePadding>
-          {todayTasks?.map((task) => (
-            <Box key={task.id}>
-              <TaskItem task={task} onEdit={handleEdit} />
-              {selectedTask?.id === task.id && (
-                <Box mt={1} mb={2}>
-                  <TaskEditor
-                    defaultFormValues={defaultTodayValues}
-                    initialData={selectedTask}
-                    onClose={handleCloseEditor}
-                    onSubmit={handleSubmit}
-                    isPending={isPendingUpdate}
-                  />
-                </Box>
-              )}
-            </Box>
-          ))}
-        </List>
-      </Box>
-
-      <Stack direction="row" alignItems="center" mt={2}>
-        <IconButton size="small" onClick={handleAddTask}>
-          <Add
-            sx={{
-              color: 'primary.main',
-              transform: { xs: 'scale(1.3)', md: 'scale(1)' },
-            }}
-          />
-        </IconButton>
-        <Typography sx={{ color: '#757575' }}>Add task</Typography>
-      </Stack>
-
-      {open && !selectedTask && (
-        <Box mt={2} mb={4}>
-          <TaskEditor
-            defaultFormValues={defaultTodayValues}
-            initialData={undefined}
-            onClose={handleCloseEditor}
-            onSubmit={handleSubmit}
-            isPending={isPendingAdd}
-          />
-        </Box>
+      {overdueTasks?.length && (
+        <OverdueSection overdueTasks={overdueTasks} defaultFormValues={defaultValues} />
       )}
+
+      <TaskListController
+        tasks={todayTasks}
+        title="Tasks for Today"
+        defaultFormValues={defaultTodayValues}
+      />
     </Container>
   );
 }

--- a/src/pages/TodayPage.tsx
+++ b/src/pages/TodayPage.tsx
@@ -1,28 +1,29 @@
 import type { SelectedTaskForm, TaskRequest } from '@app-types/task';
 import TaskItem from '@components/Task';
+import OverdueTask from '@components/Task/OverdueTask';
 import TaskEditor from '@components/Task/TaskEditor';
 import { useAddTask, useTaskDefaults, useTasks, useUpdateTask } from '@hooks/useTask';
 import { Add } from '@mui/icons-material';
 import { Box, Container, IconButton, List, Stack, Typography } from '@mui/material';
+import { format } from 'date-fns';
 import { useState } from 'react';
 
 function TodayPage() {
-  const { data: todayTasks } = useTasks({ due: 'today' });
+  const todayStr = format(new Date(), 'yyyy-MM-dd');
+  const { data: todayTasks } = useTasks({ dueDate: todayStr });
+  const { data: overdueTasks } = useTasks({ status: 'overdue' });
   const defaultTodayValues = useTaskDefaults('today');
-  const [selectedTask, setSelectedTask] = useState<SelectedTaskForm | undefined>(undefined);
   const [open, setOpen] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<SelectedTaskForm | undefined>(undefined);
+
   const { mutateAsync: mutateAsyncAdd, isPending: isPendingAdd } = useAddTask();
   const { mutateAsync: mutateAsyncUpdate, isPending: isPendingUpdate } = useUpdateTask();
 
   const handleSubmit = async (data: TaskRequest) => {
     try {
       if (selectedTask) {
-        const updateData = {
-          id: selectedTask.id,
-          task: data,
-        };
-        await mutateAsyncUpdate(updateData);
-        setOpen(false);
+        await mutateAsyncUpdate({ id: selectedTask.id, task: data });
+        setSelectedTask(undefined);
       } else {
         await mutateAsyncAdd(data);
       }
@@ -32,54 +33,84 @@ function TodayPage() {
   };
 
   const handleAddTask = () => {
-    setSelectedTask(undefined);
     setOpen(true);
+    setSelectedTask(undefined);
   };
 
-  const handleCloseEditor = () => setOpen(false);
-  const handleEdit = (data: SelectedTaskForm) => {
+  const handleCloseEditor = () => {
+    setOpen(false);
+    setSelectedTask(undefined);
+  };
+
+  const handleEdit = (task: SelectedTaskForm) => {
     setOpen(true);
-    setSelectedTask(data);
+    setSelectedTask(task);
   };
 
   return (
-    <div>
-      <Container
-        disableGutters
-        maxWidth={false}
-        sx={{
-          width: '100%',
-          mx: 'auto',
-          position: 'relative',
-        }}
-      >
-        <Typography variant="h1">Today</Typography>
-        <div>
-          <List component="div">
-            {todayTasks?.map((task) => (
-              <TaskItem key={task.id} task={task} onEdit={handleEdit} />
-            ))}
-          </List>
-        </div>
-        <Stack direction="row" sx={{ alignItems: 'center' }}>
-          <IconButton size="small" sx={{ mb: 0.5 }} onClick={handleAddTask}>
-            <Add sx={{ color: 'primary.main', transform: { xs: 'scale(1.3)', md: 'scale(1)' } }} />
-          </IconButton>
-          <Typography sx={{ color: '#757575' }}>Add task</Typography>
-        </Stack>
-        <Box sx={{ mt: -4 }}>
-          {open && (
-            <TaskEditor
-              defaultFormValues={defaultTodayValues}
-              initialData={selectedTask}
-              onClose={() => handleCloseEditor()}
-              onSubmit={handleSubmit}
-              isPending={isPendingAdd || isPendingUpdate}
-            />
-          )}
+    <Container
+      disableGutters
+      maxWidth={false}
+      sx={{
+        width: '100%',
+        mx: 'auto',
+        overflow: 'visible',
+        position: 'relative',
+      }}
+    >
+      <Typography variant="h1">Today</Typography>
+
+      <OverdueTask tasks={overdueTasks} handleEdit={handleEdit} />
+
+      <Box sx={{ mt: 4 }}>
+        <Typography variant="subtitle2" fontWeight="bold" color="primary">
+          Tasks for Today
+        </Typography>
+
+        <List component="div" disablePadding>
+          {todayTasks?.map((task) => (
+            <Box key={task.id}>
+              <TaskItem task={task} onEdit={handleEdit} />
+              {selectedTask?.id === task.id && (
+                <Box mt={1} mb={2}>
+                  <TaskEditor
+                    defaultFormValues={defaultTodayValues}
+                    initialData={selectedTask}
+                    onClose={handleCloseEditor}
+                    onSubmit={handleSubmit}
+                    isPending={isPendingUpdate}
+                  />
+                </Box>
+              )}
+            </Box>
+          ))}
+        </List>
+      </Box>
+
+      <Stack direction="row" alignItems="center" mt={2}>
+        <IconButton size="small" onClick={handleAddTask}>
+          <Add
+            sx={{
+              color: 'primary.main',
+              transform: { xs: 'scale(1.3)', md: 'scale(1)' },
+            }}
+          />
+        </IconButton>
+        <Typography sx={{ color: '#757575' }}>Add task</Typography>
+      </Stack>
+
+      {open && !selectedTask && (
+        <Box mt={2} mb={4}>
+          <TaskEditor
+            defaultFormValues={defaultTodayValues}
+            initialData={undefined}
+            onClose={handleCloseEditor}
+            onSubmit={handleSubmit}
+            isPending={isPendingAdd}
+          />
         </Box>
-      </Container>
-    </div>
+      )}
+    </Container>
   );
 }
 

--- a/src/pages/TodayPage.tsx
+++ b/src/pages/TodayPage.tsx
@@ -1,5 +1,86 @@
+import type { SelectedTaskForm, TaskRequest } from '@app-types/task';
+import TaskItem from '@components/Task';
+import TaskEditor from '@components/Task/TaskEditor';
+import { useAddTask, useTaskDefaults, useTasks, useUpdateTask } from '@hooks/useTask';
+import { Add } from '@mui/icons-material';
+import { Box, Container, IconButton, List, Stack, Typography } from '@mui/material';
+import { useState } from 'react';
+
 function TodayPage() {
-  return <div>TodayPage</div>;
+  const { data: todayTasks } = useTasks({ due: 'today' });
+  const defaultTodayValues = useTaskDefaults('today');
+  const [selectedTask, setSelectedTask] = useState<SelectedTaskForm | undefined>(undefined);
+  const [open, setOpen] = useState(false);
+  const { mutateAsync: mutateAsyncAdd, isPending: isPendingAdd } = useAddTask();
+  const { mutateAsync: mutateAsyncUpdate, isPending: isPendingUpdate } = useUpdateTask();
+
+  const handleSubmit = async (data: TaskRequest) => {
+    try {
+      if (selectedTask) {
+        const updateData = {
+          id: selectedTask.id,
+          task: data,
+        };
+        await mutateAsyncUpdate(updateData);
+        setOpen(false);
+      } else {
+        await mutateAsyncAdd(data);
+      }
+    } catch (e) {
+      console.error('Error: ', e);
+    }
+  };
+
+  const handleAddTask = () => {
+    setSelectedTask(undefined);
+    setOpen(true);
+  };
+
+  const handleCloseEditor = () => setOpen(false);
+  const handleEdit = (data: SelectedTaskForm) => {
+    setOpen(true);
+    setSelectedTask(data);
+  };
+
+  return (
+    <div>
+      <Container
+        disableGutters
+        maxWidth={false}
+        sx={{
+          width: '100%',
+          mx: 'auto',
+          position: 'relative',
+        }}
+      >
+        <Typography variant="h1">Today</Typography>
+        <div>
+          <List component="div">
+            {todayTasks?.map((task) => (
+              <TaskItem key={task.id} task={task} onEdit={handleEdit} />
+            ))}
+          </List>
+        </div>
+        <Stack direction="row" sx={{ alignItems: 'center' }}>
+          <IconButton size="small" sx={{ mb: 0.5 }} onClick={handleAddTask}>
+            <Add sx={{ color: 'primary.main', transform: { xs: 'scale(1.3)', md: 'scale(1)' } }} />
+          </IconButton>
+          <Typography sx={{ color: '#757575' }}>Add task</Typography>
+        </Stack>
+        <Box sx={{ mt: -4 }}>
+          {open && (
+            <TaskEditor
+              defaultFormValues={defaultTodayValues}
+              initialData={selectedTask}
+              onClose={() => handleCloseEditor()}
+              onSubmit={handleSubmit}
+              isPending={isPendingAdd || isPendingUpdate}
+            />
+          )}
+        </Box>
+      </Container>
+    </div>
+  );
 }
 
 export default TodayPage;

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -30,4 +30,9 @@ export const taskAPI = {
   deleteTask: async (id: string) => {
     return await apiClient.delete(`tasks/${id}`);
   },
+
+  countTask: async () => {
+    const res = await apiClient.get(`tasks/count`);
+    return res.data;
+  },
 };

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -8,7 +8,7 @@ const baseTheme = createTheme({
     secondary: { main: '#9C27B0' },
     success: { main: '#4CAF50' },
     warning: { main: '#FF9800' },
-    error: { main: '#F44336' },
+    error: { main: '#D1453B' },
     background: { default: '#ffff', paper: '#f5f5f5', popup: '#fafafa' },
   },
 

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -18,7 +18,7 @@ export interface ITask {
 export interface GetTasksParams {
   inbox?: boolean;
   categoryId?: string;
-  due?: string;
+  dueDate?: string;
   status?: string;
 }
 


### PR DESCRIPTION
This PR introduces the initial implementation of the Today page, along with several shared components and utilities to support task-related features across different pages.

**Summary**
- Implemented task count feature using `useQuery` to fetch and display task counts per page.
- Created the full UI for the Today page.
- Extracted common task logic and UI into reusable components:
  - `TaskListController`: handles shared CRUD logic and data fetching for tasks.
  - `TaskListSection`: handles common task list UI.
- Added `OverdueSection` to display overdue tasks within Today page.
- Introduced `useTaskDefaults` custom hook to provide context-aware default task values for Today, Inbox, Category, etc.

**Changes**
- feat: Add task count logic using `useQuery`
- feat: Build initial UI for Today page
- refactor: Extract TaskListController and TaskListSection for reuse
- feat: Add OverdueSection to Today page
- feat: Create `useTaskDefaults` hook for context-specific default form values