### PR TITLE
Add move task feature and improve task category display

### DIFF
--- a/src/components/Category/index.tsx
+++ b/src/components/Category/index.tsx
@@ -11,6 +11,7 @@ import {
   EditOutlined,
   ExpandLess,
   ExpandMore,
+  LabelOutlined,
   MoreHoriz,
 } from '@mui/icons-material';
 import {
@@ -92,7 +93,7 @@ export default function CategoryComponent() {
   return (
     <Box sx={{ mt: 5 }}>
       <div>
-        <ListItemButton sx={{ py: 0.5, pl: 3 }}>
+        <ListItemButton sx={{ py: 0.5, pl: 2 }}>
           <Stack
             direction="row"
             alignItems="center"
@@ -135,6 +136,7 @@ export default function CategoryComponent() {
                   }}
                   key={category.id}
                 >
+                  <LabelOutlined sx={{ mr: 1 }} />
                   <ListItemText
                     primary={
                       category.taskCount > 0

--- a/src/components/Task/CategorySubMenu.tsx
+++ b/src/components/Task/CategorySubMenu.tsx
@@ -1,0 +1,91 @@
+import { useCategories } from '@hooks/useCategory';
+import { Category, Inbox, LabelOutlined } from '@mui/icons-material';
+import { Menu, MenuItem, Typography } from '@mui/material';
+import { Stack } from '@mui/system';
+import { useEffect, useState } from 'react';
+
+interface CategorySubMenuProps {
+  anchorEl: HTMLElement | null;
+  onCloseMenu: () => void;
+  onSelectCategory: (categoryId: string | null, categoryName?: string) => void;
+}
+
+export default function CategorySubMenu({
+  anchorEl,
+  onCloseMenu,
+  onSelectCategory,
+}: CategorySubMenuProps) {
+  const { data: categories } = useCategories();
+  const [pendingCategory, setPendingCategory] = useState<{
+    id: string | null;
+    name?: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!anchorEl && pendingCategory) {
+      onSelectCategory(pendingCategory.id, pendingCategory.name);
+      setPendingCategory(null);
+    }
+  }, [anchorEl, pendingCategory, onSelectCategory]);
+
+  const safeCategories = categories?.length ? categories : [];
+
+  return (
+    <Menu
+      id="moveTask-menu"
+      anchorEl={anchorEl}
+      open={Boolean(anchorEl)}
+      anchorOrigin={{
+        vertical: 'top',
+        horizontal: 'left',
+      }}
+      transformOrigin={{
+        vertical: 'top',
+        horizontal: 'right',
+      }}
+      onClose={onCloseMenu}
+      sx={{ p: 2, mt: 1 }}
+      slotProps={{
+        paper: {
+          sx: {
+            width: anchorEl ? anchorEl.offsetWidth + 40 : 'auto',
+          },
+        },
+      }}
+    >
+      <MenuItem
+        sx={{ '&:hover': { color: 'secondary.main' } }}
+        onClick={() => {
+          setPendingCategory({ id: null });
+          onCloseMenu();
+        }}
+      >
+        <Inbox sx={{ mr: 1, color: '#0000008a' }} />
+        Inbox
+      </MenuItem>
+
+      {safeCategories?.length > 0 && (
+        <Stack direction={'row'} spacing={0.5} sx={{ ml: 2, alignItems: 'center' }}>
+          <Category sx={{ color: '#0000008a' }} />
+          <Typography sx={{ py: 1, fontWeight: 'bold', color: '#00000de' }}>Categories</Typography>
+        </Stack>
+      )}
+
+      {safeCategories.map((category) => (
+        <div key={category.id}>
+          <MenuItem
+            sx={{ pl: 4, '&:hover': { color: 'secondary.main' } }}
+            disableRipple
+            onClick={() => {
+              setPendingCategory({ id: category.id, name: category.name });
+              onCloseMenu();
+            }}
+          >
+            <LabelOutlined sx={{ mr: 1 }} />
+            {category.name}
+          </MenuItem>
+        </div>
+      ))}
+    </Menu>
+  );
+}

--- a/src/components/Task/OverdueSection.tsx
+++ b/src/components/Task/OverdueSection.tsx
@@ -32,6 +32,7 @@ export default function OverdueSection({ overdueTasks, defaultFormValues }: Prop
           defaultFormValues={defaultFormValues}
           allowAdd={false}
           showDueDate={true}
+          showCategory={true}
         />
       )}
     </Box>

--- a/src/components/Task/TaskListController.tsx
+++ b/src/components/Task/TaskListController.tsx
@@ -8,6 +8,7 @@ type Props = {
   defaultFormValues: TaskFormValues;
   allowAdd?: boolean;
   showDueDate?: boolean;
+  showCategory?: boolean;
 };
 
 export default function TaskListController({
@@ -16,6 +17,7 @@ export default function TaskListController({
   defaultFormValues,
   allowAdd = true,
   showDueDate,
+  showCategory = false,
 }: Props) {
   const {
     selectedTask,
@@ -43,6 +45,7 @@ export default function TaskListController({
       isPendingUpdate={isPendingUpdate}
       allowAdd={allowAdd}
       showDueDate={showDueDate}
+      showCategory={showCategory}
     />
   );
 }

--- a/src/components/Task/TaskListSection.tsx
+++ b/src/components/Task/TaskListSection.tsx
@@ -18,6 +18,7 @@ type TaskListSectionProps = {
   onCloseEditor: () => void;
   allowAdd?: boolean;
   showDueDate?: boolean;
+  showCategory?: boolean;
 };
 
 export default function TaskListSection({
@@ -34,6 +35,7 @@ export default function TaskListSection({
   onCloseEditor,
   allowAdd,
   showDueDate,
+  showCategory,
 }: TaskListSectionProps) {
   return (
     <Box>
@@ -46,7 +48,12 @@ export default function TaskListSection({
       <List disablePadding>
         {tasks?.map((task) => (
           <Box key={task.id}>
-            <TaskItem task={task} onEdit={onEdit} showDueDate={showDueDate} />
+            <TaskItem
+              task={task}
+              onEdit={onEdit}
+              showDueDate={showDueDate}
+              showCategory={showCategory}
+            />
             {selectedTask?.id === task.id && (
               <Box my={1} width="100%" zIndex={1} position="relative" border="1px solid #fff">
                 <TaskEditor

--- a/src/components/upcoming/TaskListControllerVirtualized.tsx
+++ b/src/components/upcoming/TaskListControllerVirtualized.tsx
@@ -10,6 +10,7 @@ type Props = {
   defaultFormValues: TaskFormValues;
   allowAdd?: boolean;
   showDueDate?: boolean;
+  showCategory?: boolean;
   onHeightChange?: () => void;
 };
 
@@ -19,6 +20,7 @@ export default function TaskListControllerVirtualized({
   defaultFormValues,
   allowAdd = true,
   showDueDate,
+  showCategory = true,
   onHeightChange,
 }: Props) {
   const {
@@ -54,6 +56,7 @@ export default function TaskListControllerVirtualized({
       isPendingUpdate={isPendingUpdate}
       allowAdd={allowAdd}
       showDueDate={showDueDate}
+      showCategory={showCategory}
     />
   );
 }

--- a/src/pages/TodayPage.tsx
+++ b/src/pages/TodayPage.tsx
@@ -32,6 +32,7 @@ function TodayPage() {
         tasks={todayTasks}
         title="Tasks for Today"
         defaultFormValues={defaultTodayValues}
+        showCategory={true}
       />
     </Container>
   );

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -13,6 +13,6 @@ export const PRIORITY_META: Record<
 > = {
   URGENT: { label: 'Urgent', display: 'Priority 1', color: '#dc3545' },
   HIGH: { label: 'High', display: 'Priority 2', color: '#fd7e14' },
-  MEDIUM: { label: 'Medium', display: 'Priority 3', color: '#0d6efd' },
+  MEDIUM: { label: 'Medium', display: 'Priority 3', color: '#009688' },
   LOW: { label: 'Low', display: 'Priority 4', color: '#6c757d' },
 };

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -44,6 +44,7 @@ export type PatchTaskDto = {
   dueDate?: string;
   priority?: number;
   isCompleted?: boolean;
+  categoryId?: string | null;
 };
 
 export interface PatchTaskRequest {


### PR DESCRIPTION
**Description**
- This PR adds the ability to move a task to a specific category, allowing users to organize tasks more effectively.
- It also includes several UI/UX improvements:
  - Adds a category icon next to the task title
  - Displays the task’s current category using a Chip in both `TodayPage` and `UpcomingPage`

**Changes**
- Implement moving task between categories (including moving to `Inbox`) using TanStack Query
- Improve UX by showing category in each task item
- Replace `visibility` with `pointerEvents` for toggling action icons on hover