### PR TITLE
Add dueTime support and reminder setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-virtual": "^3.13.12",
     "axios": "^1.9.0",
     "date-fns": "^4.1.0",
+    "firebase": "^12.7.0",
     "framer-motion": "^12.16.0",
     "notistack": "^3.0.2",
     "qs": "^6.14.0",

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,21 @@
+importScripts(
+  "https://www.gstatic.com/firebasejs/12.7.0/firebase-app-compat.js"
+);
+importScripts(
+  "https://www.gstatic.com/firebasejs/12.7.0/firebase-messaging-compat.js"
+);
+
+firebase.initializeApp({
+  apiKey: "AIzaSyCc91HVd0odTUexuik6u11SuGrSwxqODto",
+  projectId: "tasko-f1748",
+  messagingSenderId: "394433719296",
+  appId: "1:394433719296:web:2a9660e1b8172a33cc3ce5",
+});
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage((payload) => {
+  self.registration.showNotification(payload.notification.title, {
+    body: payload.notification.body,
+  });
+});

--- a/src/components/Task/DateTimePickerButton.tsx
+++ b/src/components/Task/DateTimePickerButton.tsx
@@ -43,14 +43,10 @@ function DateTimePickerButton({ date, time, onChange }: DateTimePickerButtonProp
   const handleDialogClose = () => {
     setDialogOpen(false);
     setTimePickerOpen(false);
-    // Reset temp values on close
-    setTempDate(null);
-    setTempTime(null);
   };
 
   const handleSave = () => {
-    if (!tempDate) return;
-    onChange(tempDate, tempTime);
+    onChange(tempDate, tempDate ? tempTime : null);
     handleDialogClose();
   };
 
@@ -103,18 +99,13 @@ function DateTimePickerButton({ date, time, onChange }: DateTimePickerButtonProp
                   value={tempDate}
                   minDate={startOfToday()}
                   onChange={(newDate) => {
-                    if (newDate) {
-                      setTempDate(newDate);
+                    setTempDate(newDate);
+                    if (!newDate) {
+                      setTempTime(null);
                     }
                   }}
                   views={['day']}
                   showDaysOutsideCurrentMonth
-                  sx={{
-                    '& .MuiPickersDay-today:not(.Mui-selected)': {
-                      border: tempDate ? '1px solid' : '1px dashed rgba(0, 0, 0, 0.2)',
-                      backgroundColor: 'transparent',
-                    },
-                  }}
                 />
 
                 <Divider />

--- a/src/components/Task/DateTimePickerButton.tsx
+++ b/src/components/Task/DateTimePickerButton.tsx
@@ -1,0 +1,185 @@
+import { AccessAlarm, CalendarMonth, Clear, ExpandMore } from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  ClickAwayListener,
+  Dialog,
+  DialogContent,
+  Divider,
+  IconButton,
+  InputAdornment,
+  Paper,
+  Popper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+import { format, startOfToday } from 'date-fns';
+import { useEffect, useRef, useState } from 'react';
+import TimePicker from './TimePicker';
+
+type DateTimePickerButtonProps = {
+  date: Date | null;
+  time: string | null;
+  onChange: (date: Date | null, time: string | null) => void;
+};
+
+function DateTimePickerButton({ date, time, onChange }: DateTimePickerButtonProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [tempDate, setTempDate] = useState<Date | null>(null);
+  const [tempTime, setTempTime] = useState<string | null>(null);
+  const [timePickerOpen, setTimePickerOpen] = useState(false);
+  const timeFieldRef = useRef<HTMLInputElement | null>(null);
+
+  // Reset temp values when dialog opens
+  useEffect(() => {
+    if (dialogOpen) {
+      setTempDate(date);
+      setTempTime(time);
+    }
+  }, [dialogOpen, date, time]);
+
+  const handleDialogClose = () => {
+    setDialogOpen(false);
+    setTimePickerOpen(false);
+    // Reset temp values on close
+    setTempDate(null);
+    setTempTime(null);
+  };
+
+  const handleSave = () => {
+    if (!tempDate) return;
+    onChange(tempDate, tempTime);
+    handleDialogClose();
+  };
+
+  const handleClear = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onChange(null, null);
+  };
+
+  return (
+    <>
+      {/* Trigger Button  */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          border: '1px solid',
+          borderColor: date ? 'primary.main' : '#c4c4c4',
+          borderRadius: 1,
+          bgcolor: date ? '#d1eaff' : 'transparent',
+          padding: '1px 6px',
+          fontSize: '0.75rem',
+          color: date ? 'primary.main' : '#6c757d',
+          cursor: 'pointer',
+          gap: 0.5,
+          minWidth: 'fit-content',
+        }}
+        onClick={() => setDialogOpen(true)}
+      >
+        <CalendarMonth sx={{ fontSize: 16 }} />
+        <Box sx={{ flex: 1, whiteSpace: 'nowrap' }}>
+          {date && time
+            ? `${format(date, 'd MMM')} ${time}`
+            : date
+              ? format(date, 'd MMM')
+              : 'Date'}
+        </Box>
+        {date && (
+          <IconButton size="small" onClick={handleClear} sx={{ padding: '2px' }}>
+            <Clear sx={{ fontSize: 16 }} />
+          </IconButton>
+        )}
+      </Box>
+
+      <Dialog open={dialogOpen} onClose={handleDialogClose}>
+        <DialogContent sx={{ p: 0 }}>
+          <Paper sx={{ borderRadius: 1, border: '1px solid divider' }}>
+            <Box sx={{ p: 2 }}>
+              <Stack spacing={1}>
+                <DateCalendar
+                  value={tempDate}
+                  minDate={startOfToday()}
+                  onChange={(newDate) => {
+                    if (newDate) {
+                      setTempDate(newDate);
+                    }
+                  }}
+                  views={['day']}
+                  showDaysOutsideCurrentMonth
+                  sx={{
+                    '& .MuiPickersDay-today:not(.Mui-selected)': {
+                      border: tempDate ? '1px solid' : '1px dashed rgba(0, 0, 0, 0.2)',
+                      backgroundColor: 'transparent',
+                    },
+                  }}
+                />
+
+                <Divider />
+
+                <Stack direction="row" alignItems="center" spacing={1}>
+                  <AccessAlarm fontSize="small" />
+                  <Typography fontSize={14}>Time:</Typography>
+
+                  <TextField
+                    size="small"
+                    placeholder="--:--"
+                    value={tempTime ?? ''}
+                    inputRef={timeFieldRef}
+                    disabled={!tempDate}
+                    onClick={() => tempDate && setTimePickerOpen(true)}
+                    sx={{ flex: 1 }}
+                    slotProps={{
+                      input: {
+                        readOnly: true,
+                        endAdornment: (
+                          <InputAdornment position="end">
+                            <ExpandMore fontSize="small" />
+                          </InputAdornment>
+                        ),
+                      },
+                    }}
+                  />
+                </Stack>
+
+                {/* Time Picker Popper  */}
+                <Popper
+                  open={timePickerOpen}
+                  anchorEl={timeFieldRef.current}
+                  placement="bottom-start"
+                  style={{ zIndex: 1300 }}
+                >
+                  <ClickAwayListener onClickAway={() => setTimePickerOpen(false)}>
+                    <Paper sx={{ maxHeight: 180, overflowY: 'auto', mt: 0.5 }}>
+                      <TimePicker
+                        value={tempTime}
+                        selectedDate={tempDate}
+                        onChange={(time) => {
+                          setTempTime(time);
+                          setTimePickerOpen(false);
+                        }}
+                      />
+                    </Paper>
+                  </ClickAwayListener>
+                </Popper>
+
+                <Stack direction="row" spacing={1.5} pt={1}>
+                  <Button fullWidth variant="outlined" onClick={handleDialogClose}>
+                    Cancel
+                  </Button>
+                  <Button fullWidth variant="contained" disabled={!tempDate} onClick={handleSave}>
+                    Save
+                  </Button>
+                </Stack>
+              </Stack>
+            </Box>
+          </Paper>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+export default DateTimePickerButton;

--- a/src/components/Task/TaskEditor.tsx
+++ b/src/components/Task/TaskEditor.tsx
@@ -1,5 +1,5 @@
 import type { SelectedTaskForm, TaskFormValues, TaskRequest } from '@app-types/task';
-import { Clear, Flag } from '@mui/icons-material';
+import { AccessAlarm, Clear, Flag } from '@mui/icons-material';
 import {
   Box,
   Button,
@@ -16,6 +16,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { format, startOfToday } from 'date-fns';
 import { useEffect, useState } from 'react';
 import { PRIORITY_META, PriorityLevel } from '@app-types/enum';
+import { useReminder } from '@hooks/notifications/useReminder';
 
 type TaskEditorProps = {
   defaultFormValues: TaskFormValues;
@@ -35,6 +36,8 @@ function TaskEditor({
   const { control, handleSubmit, watch, reset } = useForm<TaskFormValues>({
     defaultValues: defaultFormValues,
   });
+
+  const { handleReminderClick } = useReminder();
 
   useEffect(() => {
     if (initialData) {
@@ -211,6 +214,21 @@ function TaskEditor({
                 </>
               )}
             />
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<AccessAlarm />}
+              sx={{
+                fontWeight: 'normal',
+                padding: '1px 3px',
+                color: '#6c757d',
+                fontSize: '0.75rem',
+                borderColor: '#c4c4c4',
+              }}
+              onClick={handleReminderClick}
+            >
+              Reminders
+            </Button>
           </Stack>
 
           <Divider />

--- a/src/components/Task/TimePicker.tsx
+++ b/src/components/Task/TimePicker.tsx
@@ -44,7 +44,7 @@ const getNearestFutureTime = (): Date => {
 
 type TimePickerProps = {
   value: string | null; // "HH:mm"
-  onChange: (time: string) => void;
+  onChange: (time: string | null) => void;
   selectedDate?: Date | null;
 };
 

--- a/src/components/Task/TimePicker.tsx
+++ b/src/components/Task/TimePicker.tsx
@@ -1,0 +1,132 @@
+import { Box, List, ListItemButton } from '@mui/material';
+import {
+  format,
+  getHours,
+  getMinutes,
+  isSameDay,
+  roundToNearestMinutes,
+  setHours,
+  setMinutes,
+  startOfToday,
+} from 'date-fns';
+import { useEffect, useMemo, useRef } from 'react';
+
+const generateTimes = () => {
+  const times: Date[] = [];
+  const base = new Date();
+
+  for (let h = 0; h < 24; h++) {
+    for (let m = 0; m < 60; m += 15) {
+      times.push(setMinutes(setHours(base, h), m));
+    }
+  }
+
+  return times;
+};
+
+const ALL_TIMES = generateTimes();
+
+const timeStringToDate = (time: string): Date => {
+  const [h, m] = time.split(':').map(Number);
+  return setMinutes(setHours(new Date(), h), m);
+};
+
+const getNearestFutureTime = (): Date => {
+  const now = new Date();
+  const rounded = roundToNearestMinutes(now, { nearestTo: 15 });
+
+  if (rounded < now) {
+    rounded.setMinutes(rounded.getMinutes() + 15);
+  }
+
+  return rounded;
+};
+
+type TimePickerProps = {
+  value: string | null; // "HH:mm"
+  onChange: (time: string) => void;
+  selectedDate?: Date | null;
+};
+
+function TimePicker({ value, onChange, selectedDate }: TimePickerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLElement | null)[]>([]);
+
+  // Filter available times
+  const availableTimes = useMemo(() => {
+    if (!selectedDate) return ALL_TIMES;
+
+    if (isSameDay(selectedDate, startOfToday())) {
+      const minTime = getNearestFutureTime();
+      const minH = getHours(minTime);
+      const minM = getMinutes(minTime);
+
+      return ALL_TIMES.filter((time) => {
+        const h = getHours(time);
+        const m = getMinutes(time);
+        return h > minH || (h === minH && m >= minM);
+      });
+    }
+
+    return ALL_TIMES;
+  }, [selectedDate]);
+
+  // Auto scroll
+  useEffect(() => {
+    let targetTime: Date;
+
+    if (value) {
+      targetTime = roundToNearestMinutes(timeStringToDate(value), {
+        nearestTo: 15,
+      });
+    } else if (selectedDate && isSameDay(selectedDate, startOfToday())) {
+      targetTime = getNearestFutureTime();
+    } else {
+      targetTime = setMinutes(setHours(new Date(), 0), 0);
+    }
+
+    const targetStr = format(targetTime, 'HH:mm');
+
+    const index = availableTimes.findIndex((time) => format(time, 'HH:mm') === targetStr);
+
+    if (index >= 0 && itemRefs.current[index]) {
+      itemRefs.current[index]!.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
+    }
+  }, [value, selectedDate, availableTimes]);
+
+  return (
+    <Box
+      ref={containerRef}
+      sx={{
+        maxHeight: 180,
+        overflowY: 'auto',
+        borderTop: '1px solid #eee',
+      }}
+    >
+      <List dense>
+        {availableTimes.map((time, index) => {
+          const timeStr = format(time, 'HH:mm');
+          const selected = value === timeStr;
+
+          return (
+            <ListItemButton
+              key={timeStr}
+              selected={selected}
+              ref={(el) => {
+                itemRefs.current[index] = el;
+              }}
+              onClick={() => onChange(timeStr)}
+            >
+              {timeStr}
+            </ListItemButton>
+          );
+        })}
+      </List>
+    </Box>
+  );
+}
+
+export default TimePicker;

--- a/src/components/Task/index.tsx
+++ b/src/components/Task/index.tsx
@@ -29,7 +29,7 @@ import { useDeleteTask, usePatchTask } from '@hooks/useTask';
 import { enqueueSnackbar } from 'notistack';
 import { mapTaskToForm } from 'src/utils/task';
 import ConfirmDeleteDialog from './ConfirmDeleteDialog';
-import { format, isBefore, startOfToday } from 'date-fns';
+import { format } from 'date-fns';
 import CategorySubMenu from './CategorySubMenu';
 import { formatVnTime } from 'src/utils/times';
 
@@ -48,7 +48,6 @@ function TaskItem({ task, onEdit, showDueDate, showCategory }: TaskItemProps) {
   const [openDeleteConfirm, setOpenDeleteConfirm] = useState(false);
   const { mutateAsync } = usePatchTask();
   const { mutateAsync: mutateAsyncDelete } = useDeleteTask();
-  const isOverdue = task.dueDate && isBefore(new Date(task.dueDate), startOfToday());
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [subAnchorEl, setSubAnchorEl] = useState<HTMLElement | null>(null);
@@ -173,7 +172,7 @@ function TaskItem({ task, onEdit, showDueDate, showCategory }: TaskItemProps) {
                     <Stack
                       direction="row"
                       spacing={0.5}
-                      sx={{ color: isOverdue ? 'error.main' : '#9C27B0' }}
+                      sx={{ color: task.overdue ? 'error.main' : '#9C27B0' }}
                     >
                       {showDueDate && task.dueDate && (
                         <Stack direction="row" spacing={0.5} alignItems="center">

--- a/src/components/Task/index.tsx
+++ b/src/components/Task/index.tsx
@@ -31,6 +31,7 @@ import { mapTaskToForm } from 'src/utils/task';
 import ConfirmDeleteDialog from './ConfirmDeleteDialog';
 import { format, isBefore, startOfToday } from 'date-fns';
 import CategorySubMenu from './CategorySubMenu';
+import { formatVnTime } from 'src/utils/times';
 
 type TaskItemProps = {
   task: ITask;
@@ -169,20 +170,23 @@ function TaskItem({ task, onEdit, showDueDate, showCategory }: TaskItemProps) {
                   <Stack spacing={0.2}>
                     <Typography>{task.title}</Typography>
                     <Typography variant="body2">{task.description}</Typography>
-
-                    {showDueDate && task.dueDate && (
-                      <Stack
-                        direction="row"
-                        spacing={0.5}
-                        alignItems="center"
-                        sx={{ color: isOverdue ? 'error.main' : '#9C27B0' }}
-                      >
-                        <Event sx={{ fontSize: '13px' }} />
-                        <Typography variant="caption">
-                          {format(new Date(task.dueDate), 'MMM dd')}
-                        </Typography>
-                      </Stack>
-                    )}
+                    <Stack
+                      direction="row"
+                      spacing={0.5}
+                      sx={{ color: isOverdue ? 'error.main' : '#9C27B0' }}
+                    >
+                      {showDueDate && task.dueDate && (
+                        <Stack direction="row" spacing={0.5} alignItems="center">
+                          <Event sx={{ fontSize: '13px' }} />
+                          <Typography variant="caption">
+                            {format(new Date(task.dueDate), 'MMM dd')}
+                          </Typography>
+                        </Stack>
+                      )}
+                      <Typography variant="caption">
+                        {task.dueType == 'DATE_TIME' && formatVnTime(task.dueDateTime)}
+                      </Typography>
+                    </Stack>
                   </Stack>
                   {showCategory && (
                     <Chip

--- a/src/components/Task/index.tsx
+++ b/src/components/Task/index.tsx
@@ -31,7 +31,7 @@ import { mapTaskToForm } from 'src/utils/task';
 import ConfirmDeleteDialog from './ConfirmDeleteDialog';
 import { format } from 'date-fns';
 import CategorySubMenu from './CategorySubMenu';
-import { formatVnTime } from 'src/utils/times';
+import { formatVnTime, isTaskExpired } from 'src/utils/times';
 
 type TaskItemProps = {
   task: ITask;
@@ -172,7 +172,12 @@ function TaskItem({ task, onEdit, showDueDate, showCategory }: TaskItemProps) {
                     <Stack
                       direction="row"
                       spacing={0.5}
-                      sx={{ color: task.overdue ? 'error.main' : '#9C27B0' }}
+                      sx={{
+                        color:
+                          task.overdue || isTaskExpired(task.dueDateTime)
+                            ? 'error.main'
+                            : '#9C27B0',
+                      }}
                     >
                       {showDueDate && task.dueDate && (
                         <Stack direction="row" spacing={0.5} alignItems="center">

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,0 +1,13 @@
+import { initializeApp } from "firebase/app";
+import { getMessaging } from "firebase/messaging"
+
+const firebaseConfig = {
+  apiKey: "AIzaSyCc91HVd0odTUexuik6u11SuGrSwxqODto",
+  projectId: "tasko-f1748",
+  messagingSenderId: "394433719296",
+  appId: "1:394433719296:web:2a9660e1b8172a33cc3ce5",
+};
+
+const app = initializeApp(firebaseConfig);
+
+export const messaging = getMessaging(app);

--- a/src/hooks/notifications/useForegroundNotifications.tsx
+++ b/src/hooks/notifications/useForegroundNotifications.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+import { onMessage } from 'firebase/messaging'
+import { messaging } from 'src/firebase'
+import { enqueueSnackbar } from 'notistack'
+
+export const useForegroundNotifications = () => {
+  useEffect(() => {
+    const unsubscribe = onMessage(messaging, payload => {
+      console.log('*****************Foreground message:', payload)
+
+      const title = payload.notification?.title ?? 'New notification'
+      const body = payload.notification?.body
+
+      enqueueSnackbar(
+        <div className="flex justify-center flex-col">
+            <strong>{title}</strong>
+            <br />
+            {body}
+        </div>,
+        { variant: 'info' }
+        );
+
+
+
+    })
+
+    return () => unsubscribe()
+  }, [])
+}

--- a/src/hooks/notifications/useReminder.ts
+++ b/src/hooks/notifications/useReminder.ts
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { getToken } from 'firebase/messaging';
+import { messaging } from 'src/firebase';
+import { enqueueSnackbar } from 'notistack';
+
+export const useReminder = () => {
+  const [isPermissionGranted, setIsPermissionGranted] = useState(
+    Notification.permission === 'granted'
+  );
+
+  const handleReminderClick = async () => {
+    try {
+      const permission = await Notification.requestPermission();
+
+      console.log("permission status:", permission);
+
+      if (permission !== 'granted') {
+        enqueueSnackbar(
+          'Please enable notifications to set reminders',
+          { variant: 'warning' }
+        );
+        return;
+      }
+
+      setIsPermissionGranted(true);
+
+      const registration = await navigator.serviceWorker.ready;
+
+      const token = await getToken(messaging, {
+        vapidKey: import.meta.env.VITE_VAPID_KEY,
+        serviceWorkerRegistration: registration,
+      });
+
+      console.log('FCM Token:', token);
+
+      // send token to backend 
+
+      openReminderDialog();
+
+    } catch (error) {
+      console.error('Error requesting notification permission:', error);
+    }
+  };
+
+  const openReminderDialog = () => {
+    // open reminder picker
+  };
+
+  return { handleReminderClick, isPermissionGranted };
+};

--- a/src/hooks/notifications/useReminder.ts
+++ b/src/hooks/notifications/useReminder.ts
@@ -7,6 +7,7 @@ export const useReminder = () => {
   const [isPermissionGranted, setIsPermissionGranted] = useState(
     Notification.permission === 'granted'
   );
+  const [reminderDialogOpen, setReminderDialogOpen] = useState(false);
 
   const handleReminderClick = async () => {
     try {
@@ -43,8 +44,9 @@ export const useReminder = () => {
   };
 
   const openReminderDialog = () => {
+    setReminderDialogOpen(true);
     // open reminder picker
   };
 
-  return { handleReminderClick, isPermissionGranted };
+  return { handleReminderClick, isPermissionGranted, reminderDialogOpen, setReminderDialogOpen };
 };

--- a/src/hooks/useTask.ts
+++ b/src/hooks/useTask.ts
@@ -101,6 +101,7 @@ export const useTaskDefaults = (ctx?: TaskDefaultsContext) => {
     title: '',
     description: '',
     dueDate: null,
+    dueTime: null,
     priority: PriorityLevel.LOW,
   };
 

--- a/src/hooks/useTask.ts
+++ b/src/hooks/useTask.ts
@@ -1,6 +1,12 @@
 import { PriorityLevel } from '@app-types/enum';
 import { taskAPI } from './../services/task';
-import type { GetTasksParams, ITask, SelectedTaskForm, TaskRequest } from '@app-types/task';
+import type {
+  GetTasksParams,
+  ITask,
+  SelectedTaskForm,
+  TaskFormValues,
+  TaskRequest,
+} from '@app-types/task';
 import { queryClient } from '@lib/queryClient';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { enqueueSnackbar } from 'notistack';
@@ -93,34 +99,42 @@ export const useDeleteTask = () => {
 
 type TaskDefaultsContext =
   | { context: 'inbox' }
-  | { context: 'dueDate'; dueDate: Date }
+  | { context: 'dueDate'; dueDate: Date; dueTime?: string }
   | { context: 'category'; categoryId: string };
 
 export const useTaskDefaults = (ctx?: TaskDefaultsContext) => {
-  const baseDefaults = {
+  const baseDefaults: TaskFormValues = {
     title: '',
     description: '',
+    dueType: 'NONE',
     dueDate: null,
     dueTime: null,
     priority: PriorityLevel.LOW,
   };
 
+  let defaults = { ...baseDefaults };
+
   switch (ctx?.context) {
     case 'inbox':
-      return baseDefaults;
+      break;
     case 'dueDate':
-      return {
-        ...baseDefaults,
-        dueDate: ctx.dueDate ?? null,
-      };
+      defaults.dueDate = ctx.dueDate ?? null;
+      defaults.dueTime = ctx.dueTime ?? null;
+      break;
     case 'category':
-      return {
-        ...baseDefaults,
-        categoryId: ctx.categoryId,
-      };
-    default:
-      return baseDefaults;
+      defaults.categoryId = ctx.categoryId;
+      break;
   }
+
+  if (defaults.dueDate && defaults.dueTime) {
+    defaults.dueType = 'DATE_TIME';
+  } else if (defaults.dueDate) {
+    defaults.dueType = 'DATE';
+  } else {
+    defaults.dueType = 'NONE';
+  }
+
+  return defaults;
 };
 
 export const useTaskEditor = () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,10 @@ import theme from './theme';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/firebase-messaging-sw.js');
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -1,4 +1,4 @@
-import { motion, AnimatePresence, easeOut } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 import { Box } from '@mui/material';
 import { lazy, Suspense } from 'react';
 import LoadingSpinner from '@components/common/LoadingSpinner';
@@ -13,7 +13,7 @@ const variants = {
   initial: { opacity: 0, scale: 0.98, y: 10 },
   animate: { opacity: 1, scale: 1, y: 0 },
   exit: { opacity: 0, scale: 0.98, y: -10 },
-  transition: { duration: 0.25, ease: easeOut },
+  transition: { duration: 0.25, ease: 'easeOut' },
 };
 
 export default function Auth() {
@@ -45,11 +45,11 @@ export default function Auth() {
         );
       case 'reset':
         return (
-          <Suspense fallback={<LoadingSpinner/>}>
-            <ResetPasswordForm/>
+          <Suspense fallback={<LoadingSpinner />}>
+            <ResetPasswordForm />
           </Suspense>
-        )
-      
+        );
+
       default:
         return <LoginForm />;
     }

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -1,4 +1,4 @@
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, easeOut } from 'framer-motion';
 import { Box } from '@mui/material';
 import { lazy, Suspense } from 'react';
 import LoadingSpinner from '@components/common/LoadingSpinner';
@@ -13,7 +13,7 @@ const variants = {
   initial: { opacity: 0, scale: 0.98, y: 10 },
   animate: { opacity: 1, scale: 1, y: 0 },
   exit: { opacity: 0, scale: 0.98, y: -10 },
-  transition: { duration: 0.25, ease: 'easeOut' },
+  transition: { duration: 0.25, ease: easeOut },
 };
 
 export default function Auth() {

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -8,6 +8,7 @@ import ErrorBoundary from '@components/errors/ErrorBoundary';
 import NotFound from '@components/errors/NotFound';
 import PrivateRoute from './PrivateRoute';
 import { Auth } from '@pages/index';
+import { useForegroundNotifications } from '@hooks/notifications/useForegroundNotifications';
 
 const InboxPage = lazy(() => import('@pages/InboxPage'));
 const TodayPage = lazy(() => import('@pages/TodayPage'));
@@ -88,6 +89,7 @@ const routesConfig: RouteObject[] = [
 const router = createBrowserRouter(routesConfig);
 
 const AppRouter = () => {
+  useForegroundNotifications()
   return (
     <Suspense fallback={<LoadingSpinner />}>
       <RouterProvider router={router} />

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -13,9 +13,9 @@ export interface ITask {
   isCompleted: boolean;
   completedAt?: string | null;
   category?: ICategory | null;
-  isInboxTask: boolean;
-  isTodayTask: boolean;
-  isOverdue: boolean;
+  inboxTask: boolean;
+  todayTask: boolean;
+  overdue: boolean;
 }
 
 export interface GetTasksParams {

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,11 +1,14 @@
 import type { ICategory } from './category';
 import type { PriorityLevel } from './enum';
 
+type DueType = 'NONE' | 'DATE' | 'DATE_TIME';
 export interface ITask {
   id: string;
   title: string;
   description?: string;
+  dueType: DueType;
   dueDate: string;
+  dueDateTime: string;
   priority: PriorityLevel;
   isCompleted: boolean;
   completedAt?: string | null;
@@ -21,12 +24,12 @@ export interface GetTasksParams {
   dueDate?: string;
   status?: string;
 }
-
 export interface TaskFormValues {
   title: string;
   description?: string;
+  dueType: DueType;
   dueDate?: Date | null;
-  dueTime?: string | null;
+  dueTime: string | null;
   priority: PriorityLevel;
   categoryId?: string;
 }
@@ -34,7 +37,9 @@ export interface TaskFormValues {
 export interface TaskRequest {
   title: string;
   description?: string;
-  dueAt?: string | null;
+  dueType: DueType;
+  dueDate?: string; // yyyy-MM-dd
+  dueDateTime?: string; // ISO
   priority: PriorityLevel;
   categoryId?: string;
 }

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -26,6 +26,7 @@ export interface TaskFormValues {
   title: string;
   description?: string;
   dueDate?: Date | null;
+  dueTime?: string | null;
   priority: PriorityLevel;
   categoryId?: string;
 }
@@ -33,7 +34,7 @@ export interface TaskFormValues {
 export interface TaskRequest {
   title: string;
   description?: string;
-  dueDate?: string | null;
+  dueAt?: string | null;
   priority: PriorityLevel;
   categoryId?: string;
 }

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -1,5 +1,5 @@
 import type { ITask, SelectedTaskForm, TaskFormValues, TaskRequest } from '@app-types/task';
-import { parseISO } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 
 export function convertFormToTaskRequest(form: TaskFormValues): TaskRequest {
   const taskRequest: TaskRequest = {
@@ -23,13 +23,28 @@ const formatLocalDate = (date: Date): string => {
   return `${year}-${month}-${day}`;
 };
 
-export function mapTaskToForm(task: ITask): SelectedTaskForm {
+export const mapTaskToForm = (task: ITask): SelectedTaskForm => {
+  let dueDate: Date | null = null;
+  let dueTime: string | null = null;
+
+  if (task.dueType === 'DATE_TIME' && task.dueDateTime) {
+    const dateTime = parseISO(task.dueDateTime);
+
+    dueDate = dateTime;
+    dueTime = format(dateTime, 'HH:mm');
+  } else if (task.dueDate) {
+    dueDate = parseISO(task.dueDate);
+    dueTime = null;
+  }
+
   return {
     id: task.id,
     title: task.title,
     description: task.description,
-    dueDate: task.dueDate ? parseISO(task.dueDate) : null,
+    dueType: task.dueType,
+    dueDate,
+    dueTime,
     priority: task.priority,
     categoryId: task.category?.id,
   };
-}
+};

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -1,5 +1,27 @@
-import type { ITask, SelectedTaskForm } from '@app-types/task';
+import type { ITask, SelectedTaskForm, TaskFormValues, TaskRequest } from '@app-types/task';
 import { parseISO } from 'date-fns';
+
+export function convertFormToTaskRequest(form: TaskFormValues): TaskRequest {
+  const taskRequest: TaskRequest = {
+    ...form,
+
+    dueDate: form.dueType === 'DATE' && form.dueDate ? formatLocalDate(form.dueDate) : undefined,
+
+    dueDateTime:
+      form.dueType === 'DATE_TIME' && form.dueDate && form.dueTime
+        ? new Date(`${formatLocalDate(form.dueDate)}T${form.dueTime}:00`).toISOString()
+        : undefined,
+  };
+
+  return taskRequest;
+}
+
+const formatLocalDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
 
 export function mapTaskToForm(task: ITask): SelectedTaskForm {
   return {

--- a/src/utils/times.ts
+++ b/src/utils/times.ts
@@ -1,0 +1,10 @@
+const APP_TIME_ZONE = 'Asia/Ho_Chi_Minh';
+
+export const formatVnTime = (iso: string) => {
+  return new Date(iso).toLocaleString('vi-VN', {
+    timeZone: APP_TIME_ZONE,
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+};

--- a/src/utils/times.ts
+++ b/src/utils/times.ts
@@ -1,3 +1,5 @@
+import { isBefore, parseISO } from 'date-fns';
+
 const APP_TIME_ZONE = 'Asia/Ho_Chi_Minh';
 
 export const formatVnTime = (iso: string) => {
@@ -7,4 +9,13 @@ export const formatVnTime = (iso: string) => {
     minute: '2-digit',
     hour12: false,
   });
+};
+
+export const isTaskExpired = (dueDateTime?: string) => {
+  if (!dueDateTime) return false;
+
+  const due = parseISO(dueDateTime);
+  const now = new Date();
+
+  return isBefore(due, now);
 };

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -37,5 +37,5 @@
     }
 
   },
-  "include": ["src"]
+  "include": ["src", "public/firebase-messaging-sw.js"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -626,6 +626,569 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@firebase/ai@npm:2.6.1":
+  version: 2.6.1
+  resolution: "@firebase/ai@npm:2.6.1"
+  dependencies:
+    "@firebase/app-check-interop-types": "npm:0.3.3"
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app": 0.x
+    "@firebase/app-types": 0.x
+  checksum: 10c0/c9e6d0a4acb9ddbb8d809566de8806b27677e02ee7e7455cc09235bc84639e21ad1499d43025007cebb3b2231fe78067c93a8b5b1a8f2dac905f43284a8944b5
+  languageName: node
+  linkType: hard
+
+"@firebase/analytics-compat@npm:0.2.25":
+  version: 0.2.25
+  resolution: "@firebase/analytics-compat@npm:0.2.25"
+  dependencies:
+    "@firebase/analytics": "npm:0.10.19"
+    "@firebase/analytics-types": "npm:0.8.3"
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app-compat": 0.x
+  checksum: 10c0/5cc2719caee5371516fe3a4ce628926b75a1f8ec563e4b994a9f18762037725e48f3a4313218b13bd5418cea29e7fb1109d99557863de2ac4c731e0b8cf78024
+  languageName: node
+  linkType: hard
+
+"@firebase/analytics-types@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@firebase/analytics-types@npm:0.8.3"
+  checksum: 10c0/2cbc5fe8425bc01c7ba03579cdc5ca6b23de51b08edb62927be610a33bbc961bae97aa48ee12dcdb039b752c158d095f234ed20f1f4d2bd7a5c39f44d82cdf22
+  languageName: node
+  linkType: hard
+
+"@firebase/analytics@npm:0.10.19":
+  version: 0.10.19
+  resolution: "@firebase/analytics@npm:0.10.19"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/installations": "npm:0.6.19"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app": 0.x
+  checksum: 10c0/9af9b74ad285df0b3fa04abf4653dfed436e698193f28b50bf309948b1288de21d91114fab94d7ae29a3c9950d6cbebd7355a5a752a2e936d9375fa71f26728f
+  languageName: node
+  linkType: hard
+
+"@firebase/app-check-compat@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@firebase/app-check-compat@npm:0.4.0"
+  dependencies:
+    "@firebase/app-check": "npm:0.11.0"
+    "@firebase/app-check-types": "npm:0.5.3"
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app-compat": 0.x
+  checksum: 10c0/3e171cf352faa647162a866b02b12408165a584a30899cccc1bf2c75c972332c7238d75317b71457269451acf5a30f8b1d87b441e0b32ae09dcb6f3dcec41a6f
+  languageName: node
+  linkType: hard
+
+"@firebase/app-check-interop-types@npm:0.3.3":
+  version: 0.3.3
+  resolution: "@firebase/app-check-interop-types@npm:0.3.3"
+  checksum: 10c0/4a887ef5e30ee1a407b569603c433a9f21244d50a19d97a5f1f17d8f5caea83096852b39e67d599f3238f1f7e2a369b02d184a184986a649ed1f8fed12fbd6be
+  languageName: node
+  linkType: hard
+
+"@firebase/app-check-types@npm:0.5.3":
+  version: 0.5.3
+  resolution: "@firebase/app-check-types@npm:0.5.3"
+  checksum: 10c0/59af0ae698ff2172e84f504e3b5e778c2cc78fefdcceb917eb899a204ad130ad5497011ab94459f6f9dd0a9062a0455bbd745ad3e488b39dae4625c3fb0d0145
+  languageName: node
+  linkType: hard
+
+"@firebase/app-check@npm:0.11.0":
+  version: 0.11.0
+  resolution: "@firebase/app-check@npm:0.11.0"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app": 0.x
+  checksum: 10c0/3229c02c2496d8bca9893f4dcc67fd3e97d833ca84a86de38768f3e46cde183415201683ed7d73672c720f0047e960e5855ca9dfbc4aba358b40348fa1b72833
+  languageName: node
+  linkType: hard
+
+"@firebase/app-compat@npm:0.5.6":
+  version: 0.5.6
+  resolution: "@firebase/app-compat@npm:0.5.6"
+  dependencies:
+    "@firebase/app": "npm:0.14.6"
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  checksum: 10c0/cb21a6b61de63a48ed75bf2abd6863d19c46b44841cd5cc65eddf6a33b1986748d215c05bb080a6805cf1b70fe7295740b3dc64fbc355de57d49ead190a7372b
+  languageName: node
+  linkType: hard
+
+"@firebase/app-types@npm:0.9.3":
+  version: 0.9.3
+  resolution: "@firebase/app-types@npm:0.9.3"
+  checksum: 10c0/02ec9a26c10b9bbb2a1e5b9ae0552b5325b40066e3c23be089ceae53414a1505f2ab716ae1098652a0a0c9992ba322c05371a9b2a837cccfae309788372a72e0
+  languageName: node
+  linkType: hard
+
+"@firebase/app@npm:0.14.6":
+  version: 0.14.6
+  resolution: "@firebase/app@npm:0.14.6"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/util": "npm:1.13.0"
+    idb: "npm:7.1.1"
+    tslib: "npm:^2.1.0"
+  checksum: 10c0/bc79488a20ec065929a7de8c39560c507b80e85bc892a784b1a3ba44e4f57c203b27755c6b2cb1699f13ac1f7fca7ecc7bad3de1673d4788c1f7063037ced9f9
+  languageName: node
+  linkType: hard
+
+"@firebase/auth-compat@npm:0.6.2":
+  version: 0.6.2
+  resolution: "@firebase/auth-compat@npm:0.6.2"
+  dependencies:
+    "@firebase/auth": "npm:1.12.0"
+    "@firebase/auth-types": "npm:0.13.0"
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app-compat": 0.x
+  checksum: 10c0/8eb06d4d45ef072ca196ed64b102ff8e546285c0c011e6f4b3cf0a7ddb0f66623cfff1e3bec49e26e94d40714240788e9d4eee59de2c8f9756d49828e53ec036
+  languageName: node
+  linkType: hard
+
+"@firebase/auth-interop-types@npm:0.2.4":
+  version: 0.2.4
+  resolution: "@firebase/auth-interop-types@npm:0.2.4"
+  checksum: 10c0/ff833bcbb472992c6061847309e338dac736c616522c5fd808526d6dc13b9788458a8c9677d91c33c1288ee38f42896c2b4b8fe10ee74f1569d11f3f3c4f53b5
+  languageName: node
+  linkType: hard
+
+"@firebase/auth-types@npm:0.13.0":
+  version: 0.13.0
+  resolution: "@firebase/auth-types@npm:0.13.0"
+  peerDependencies:
+    "@firebase/app-types": 0.x
+    "@firebase/util": 1.x
+  checksum: 10c0/a844c4a083ade9ae946337ec7d7fca8b0a384439be455d6d60d1ba01671c34b2b5162b7b8c1341a699fa70f78948c145c3bbe4723ca444f3b2f17cace40a4fd9
+  languageName: node
+  linkType: hard
+
+"@firebase/auth@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@firebase/auth@npm:1.12.0"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app": 0.x
+    "@react-native-async-storage/async-storage": ^2.2.0
+  peerDependenciesMeta:
+    "@react-native-async-storage/async-storage":
+      optional: true
+  checksum: 10c0/b3d87027bdba7ebad8d8d8c3e23f483d1936ad13b5356ecd6940a18a531805fa9f5f46348faae446e2971171f29223427c9287f58632d39392fc34003ddd792b
+  languageName: node
+  linkType: hard
+
+"@firebase/component@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@firebase/component@npm:0.7.0"
+  dependencies:
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  checksum: 10c0/10e78f51a0c6764dbfe3863eda05b8d6e8ec431430bec165891b0b9c0eca06faf7851c5ec6a6b669f3e0cfab5d997a6f0510b1920c0424e83162a53812220e1a
+  languageName: node
+  linkType: hard
+
+"@firebase/data-connect@npm:0.3.12":
+  version: 0.3.12
+  resolution: "@firebase/data-connect@npm:0.3.12"
+  dependencies:
+    "@firebase/auth-interop-types": "npm:0.2.4"
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app": 0.x
+  checksum: 10c0/f1134585d5e571286ed285d4385b1e6930b3efd385cbd28eacb170a8fcf6ff9427b5583d8e9343d4a06783a2c99e05411cb2a402394336b6a7ac9c98c6618269
+  languageName: node
+  linkType: hard
+
+"@firebase/database-compat@npm:2.1.0":
+  version: 2.1.0
+  resolution: "@firebase/database-compat@npm:2.1.0"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/database": "npm:1.1.0"
+    "@firebase/database-types": "npm:1.0.16"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  checksum: 10c0/f9b29c27b08915ba3310efafb5dee4fb024a9f20c66560740d1a9a8569a72a2479163a353c6ae0559f5fcab165518348f749a7bb07a5c22e446bc93826f34b8a
+  languageName: node
+  linkType: hard
+
+"@firebase/database-types@npm:1.0.16":
+  version: 1.0.16
+  resolution: "@firebase/database-types@npm:1.0.16"
+  dependencies:
+    "@firebase/app-types": "npm:0.9.3"
+    "@firebase/util": "npm:1.13.0"
+  checksum: 10c0/d67356cb4edfe01df33bb23a42c365746fa65eeb156ead03de1f5b1bb630266ec7dd46787a0f4ae3e86b23375b47ddcef255b508aae7c7a9343800dbcc0b5c50
+  languageName: node
+  linkType: hard
+
+"@firebase/database@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@firebase/database@npm:1.1.0"
+  dependencies:
+    "@firebase/app-check-interop-types": "npm:0.3.3"
+    "@firebase/auth-interop-types": "npm:0.2.4"
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/util": "npm:1.13.0"
+    faye-websocket: "npm:0.11.4"
+    tslib: "npm:^2.1.0"
+  checksum: 10c0/1c7b1fb310b9f2ddab2dec652b2686b614b9adaae360a7e336eda905c18a6f38c89e17d90ff251f4189576108ef1ee7832b70e492dfcc0c8d580b7f606dc9b14
+  languageName: node
+  linkType: hard
+
+"@firebase/firestore-compat@npm:0.4.3":
+  version: 0.4.3
+  resolution: "@firebase/firestore-compat@npm:0.4.3"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/firestore": "npm:4.9.3"
+    "@firebase/firestore-types": "npm:3.0.3"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app-compat": 0.x
+  checksum: 10c0/20216e86e1217fe42b29d5ffe030919d5a411088ccbcd59c61693a70e8282d400cc2ebf0f118a30c8d96693e398b89c619d5840a17692f95c1aa70e535034d83
+  languageName: node
+  linkType: hard
+
+"@firebase/firestore-types@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@firebase/firestore-types@npm:3.0.3"
+  peerDependencies:
+    "@firebase/app-types": 0.x
+    "@firebase/util": 1.x
+  checksum: 10c0/8196168a2de68bd60e0a9053a670d14d2917bf8e30829a4a2f8435fa2aceaaf97ce7438cd9525786a9bf8c5d6104ced3086acd792439371fea7b35497a53bdfa
+  languageName: node
+  linkType: hard
+
+"@firebase/firestore@npm:4.9.3":
+  version: 4.9.3
+  resolution: "@firebase/firestore@npm:4.9.3"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/util": "npm:1.13.0"
+    "@firebase/webchannel-wrapper": "npm:1.0.5"
+    "@grpc/grpc-js": "npm:~1.9.0"
+    "@grpc/proto-loader": "npm:^0.7.8"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app": 0.x
+  checksum: 10c0/f5502fa6f8bdc3d8033ddc4157c2f29c00eae35ee1912c54bf66dc236a71a223ae349c7132878ff9e6c58f0488d02f58ec151bcf5750071efb010a456fac8c11
+  languageName: node
+  linkType: hard
+
+"@firebase/functions-compat@npm:0.4.1":
+  version: 0.4.1
+  resolution: "@firebase/functions-compat@npm:0.4.1"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/functions": "npm:0.13.1"
+    "@firebase/functions-types": "npm:0.6.3"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app-compat": 0.x
+  checksum: 10c0/3ad638e7e29e5a795ee4009787c442f8e319782780499de4e31889d931db8e7822559e0fb46b899f0306bcb740ef687c2144609c6b3ca62760d24697f7cf330b
+  languageName: node
+  linkType: hard
+
+"@firebase/functions-types@npm:0.6.3":
+  version: 0.6.3
+  resolution: "@firebase/functions-types@npm:0.6.3"
+  checksum: 10c0/aabd7bdd8c479323a419bba9ad275d96cd44229bd2213c87be08a9978af5ff0c1306279229a358c77280ce54fa6f42c91a6fd6c947808b1103174db0261b86e1
+  languageName: node
+  linkType: hard
+
+"@firebase/functions@npm:0.13.1":
+  version: 0.13.1
+  resolution: "@firebase/functions@npm:0.13.1"
+  dependencies:
+    "@firebase/app-check-interop-types": "npm:0.3.3"
+    "@firebase/auth-interop-types": "npm:0.2.4"
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/messaging-interop-types": "npm:0.2.3"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app": 0.x
+  checksum: 10c0/cf2436708142c1b6aee5808dd76cbc7ed66b1448e806f3c1b8793f24b9bfc6963039eaf1fe84c3d1e0d121cee95d23e646dee4f92fe1d94f9ee73973b12c36dc
+  languageName: node
+  linkType: hard
+
+"@firebase/installations-compat@npm:0.2.19":
+  version: 0.2.19
+  resolution: "@firebase/installations-compat@npm:0.2.19"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/installations": "npm:0.6.19"
+    "@firebase/installations-types": "npm:0.5.3"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app-compat": 0.x
+  checksum: 10c0/666dee235b73defe2a0c34a00be1e8f91612fc33c9ba5b3c1a21a076afc891d274b94cd094da37bfb1809a3971df2dead88345aaf78504bf788326847b8f4d3b
+  languageName: node
+  linkType: hard
+
+"@firebase/installations-types@npm:0.5.3":
+  version: 0.5.3
+  resolution: "@firebase/installations-types@npm:0.5.3"
+  peerDependencies:
+    "@firebase/app-types": 0.x
+  checksum: 10c0/f8af07a17e9c0cd1738009b880579b57d112f991ac99e4a17f327d89ad9f8f633fd50757bfd97f470edcc62045526dc59432fb7fcb1f76daa3c72c975519af62
+  languageName: node
+  linkType: hard
+
+"@firebase/installations@npm:0.6.19":
+  version: 0.6.19
+  resolution: "@firebase/installations@npm:0.6.19"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/util": "npm:1.13.0"
+    idb: "npm:7.1.1"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app": 0.x
+  checksum: 10c0/c0fe4cf11f4ae9e3d6dcb59db1e559ed691b57d9f61c5ddd3ca36d4f4ce8d7d7fc6c97437f83cc0b612a0a19050dbde9e53085044318cd889ee1ef0fa09410b1
+  languageName: node
+  linkType: hard
+
+"@firebase/logger@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@firebase/logger@npm:0.5.0"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  checksum: 10c0/c9bfa2381b89b7dc674aeaaa497b73076041c56d6d65cbebcb3227c264b737394528d7f94658a7acb169bd14793cfcb33865207b2d32a7a6ac858e68c5c61b7e
+  languageName: node
+  linkType: hard
+
+"@firebase/messaging-compat@npm:0.2.23":
+  version: 0.2.23
+  resolution: "@firebase/messaging-compat@npm:0.2.23"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/messaging": "npm:0.12.23"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app-compat": 0.x
+  checksum: 10c0/f52c46cea3c14faca185a8605ca03bd741e70bba1c1277f849170756549e0abca00cf0c1ae22c4ce3ec83b72d6a9438cee8ef5cfef57156b76be55308844d602
+  languageName: node
+  linkType: hard
+
+"@firebase/messaging-interop-types@npm:0.2.3":
+  version: 0.2.3
+  resolution: "@firebase/messaging-interop-types@npm:0.2.3"
+  checksum: 10c0/a6fb8f02db6a93f277cb5bd530934509e49465f775f2b5ed159116d9ce30b6255213781639b98984ff8b424a8fc36a8e5779e0cc3f0cf5e1bdbd41ae938d6c39
+  languageName: node
+  linkType: hard
+
+"@firebase/messaging@npm:0.12.23":
+  version: 0.12.23
+  resolution: "@firebase/messaging@npm:0.12.23"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/installations": "npm:0.6.19"
+    "@firebase/messaging-interop-types": "npm:0.2.3"
+    "@firebase/util": "npm:1.13.0"
+    idb: "npm:7.1.1"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app": 0.x
+  checksum: 10c0/6c0ca7bc41149261420ac4385921d421656be8a388be5caa0bfb28ba16093aa8e7df30707ab0e5ddeadc2778e81beb2e945d72a2908248b2a1ae7c2bd6711592
+  languageName: node
+  linkType: hard
+
+"@firebase/performance-compat@npm:0.2.22":
+  version: 0.2.22
+  resolution: "@firebase/performance-compat@npm:0.2.22"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/performance": "npm:0.7.9"
+    "@firebase/performance-types": "npm:0.2.3"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app-compat": 0.x
+  checksum: 10c0/259f73da8cd8a70a0ccc77230ebdedbe98e62d5a01d888d3b155997a70bcd218a4fb373b6a81773cf599b17ec1e8edfcc9e6fef0f9778d4744d15d58207453c1
+  languageName: node
+  linkType: hard
+
+"@firebase/performance-types@npm:0.2.3":
+  version: 0.2.3
+  resolution: "@firebase/performance-types@npm:0.2.3"
+  checksum: 10c0/971d6bff448481dd5e8ff9d643e14b364ed4d619aca1d8d64105555c7f4566c9c05bca3cd0c027b3f879cccf8c7bc0e31579f7f0d7b8b1de182af804572b2374
+  languageName: node
+  linkType: hard
+
+"@firebase/performance@npm:0.7.9":
+  version: 0.7.9
+  resolution: "@firebase/performance@npm:0.7.9"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/installations": "npm:0.6.19"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+    web-vitals: "npm:^4.2.4"
+  peerDependencies:
+    "@firebase/app": 0.x
+  checksum: 10c0/921905e23657a7537569f85291290bce3e95ddbc067618f83fa98050b014da2fd8af7b63ab10f6f35ffd53ede8262ce9224bcfe7e06d071060977b8a5cb52b5b
+  languageName: node
+  linkType: hard
+
+"@firebase/remote-config-compat@npm:0.2.20":
+  version: 0.2.20
+  resolution: "@firebase/remote-config-compat@npm:0.2.20"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/remote-config": "npm:0.7.0"
+    "@firebase/remote-config-types": "npm:0.5.0"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app-compat": 0.x
+  checksum: 10c0/1fbd20e9274df8e6ecc2498fa1562c506ffb29e920402f8cccbfa10535664d56fa8f4d4acc13a01b09ed3cc94c77cad38d14c6c2f4b223ac8e7ad98d56215164
+  languageName: node
+  linkType: hard
+
+"@firebase/remote-config-types@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@firebase/remote-config-types@npm:0.5.0"
+  checksum: 10c0/350f9b1b5bc7bd294fe64fbd6b29f09f8aad7142e1c6fd4093a4136719cc3e89993f54daf6418b1e94bab5cc4b5b3d0fd1985f1e904d0813b18757184bbeaca0
+  languageName: node
+  linkType: hard
+
+"@firebase/remote-config@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@firebase/remote-config@npm:0.7.0"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/installations": "npm:0.6.19"
+    "@firebase/logger": "npm:0.5.0"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app": 0.x
+  checksum: 10c0/840904660b671969d9bb72cea0af77aaef46491711d76a0dea2a637c512c3f7b65dfc1fa4635c202f14de9da47108cccc94e8fcf7a1a25e380a8e2e448a0c70d
+  languageName: node
+  linkType: hard
+
+"@firebase/storage-compat@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@firebase/storage-compat@npm:0.4.0"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/storage": "npm:0.14.0"
+    "@firebase/storage-types": "npm:0.8.3"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app-compat": 0.x
+  checksum: 10c0/16e868afdfd67c89919e69a4d2916899f6807e03a33b5bf03a563942ee35a7858929df846d6be8d3d712ea4482683a31dbf9c48979352d3ef87962f7e1dc3705
+  languageName: node
+  linkType: hard
+
+"@firebase/storage-types@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@firebase/storage-types@npm:0.8.3"
+  peerDependencies:
+    "@firebase/app-types": 0.x
+    "@firebase/util": 1.x
+  checksum: 10c0/4b34edca4fcbf75ba6575b02d823f5f5b0680977488a2e8101116313903d75973623cf4440f1e0f8048158e0804d0f5a7730f15bbe5af4ceb35fae6ff532a696
+  languageName: node
+  linkType: hard
+
+"@firebase/storage@npm:0.14.0":
+  version: 0.14.0
+  resolution: "@firebase/storage@npm:0.14.0"
+  dependencies:
+    "@firebase/component": "npm:0.7.0"
+    "@firebase/util": "npm:1.13.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    "@firebase/app": 0.x
+  checksum: 10c0/7a210db11c698dfeff57bdf8c883d0d595a8ddef25eadd144d7501747d1f0e429c073beb9d1e871e5bad8e6dc1eda10f3fb2288290349e6058b5bad7e042e7f1
+  languageName: node
+  linkType: hard
+
+"@firebase/util@npm:1.13.0":
+  version: 1.13.0
+  resolution: "@firebase/util@npm:1.13.0"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  checksum: 10c0/2e0c19dffdf69a1d1f8d786de551268d6af804de857eb195f4af50b732fe9e696cb73c52abc5f0bc98b34527225fb97a81ec380e89bd47a1d8448fc66536845c
+  languageName: node
+  linkType: hard
+
+"@firebase/webchannel-wrapper@npm:1.0.5":
+  version: 1.0.5
+  resolution: "@firebase/webchannel-wrapper@npm:1.0.5"
+  checksum: 10c0/d48c452cd690894ab67b34f8e22d0e48cf238e6643c7850aefa25145e2c268aaa5e3b5aa1cb779efc240d1b0d001e5748c3db52cc1620b0f3b2f55695de5fcca
+  languageName: node
+  linkType: hard
+
+"@grpc/grpc-js@npm:~1.9.0":
+  version: 1.9.15
+  resolution: "@grpc/grpc-js@npm:1.9.15"
+  dependencies:
+    "@grpc/proto-loader": "npm:^0.7.8"
+    "@types/node": "npm:>=12.12.47"
+  checksum: 10c0/5bd40e1b886df238f8ffe4cab694ceb51250f94ede7da6f94233b4d9a2526a4e525aafbc8f319850c2d8126c189232be458991768877b2af441f0234fb4b4292
+  languageName: node
+  linkType: hard
+
+"@grpc/proto-loader@npm:^0.7.8":
+  version: 0.7.15
+  resolution: "@grpc/proto-loader@npm:0.7.15"
+  dependencies:
+    lodash.camelcase: "npm:^4.3.0"
+    long: "npm:^5.0.0"
+    protobufjs: "npm:^7.2.5"
+    yargs: "npm:^17.7.2"
+  bin:
+    proto-loader-gen-types: build/bin/proto-loader-gen-types.js
+  checksum: 10c0/514a134a724b56d73d0a202b7e02c84479da21e364547bacb2f4995ebc0d52412a1a21653add9f004ebd146c1e6eb4bcb0b8846fdfe1bfa8a98ed8f3d203da4a
+  languageName: node
+  linkType: hard
+
 "@humanfs/core@npm:^0.19.1":
   version: 0.19.1
   resolution: "@humanfs/core@npm:0.19.1"
@@ -1014,6 +1577,79 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/aspromise@npm:1.1.2"
+  checksum: 10c0/a83343a468ff5b5ec6bff36fd788a64c839e48a07ff9f4f813564f58caf44d011cd6504ed2147bf34835bd7a7dd2107052af755961c6b098fd8902b4f6500d0f
+  languageName: node
+  linkType: hard
+
+"@protobufjs/base64@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/base64@npm:1.1.2"
+  checksum: 10c0/eec925e681081af190b8ee231f9bad3101e189abbc182ff279da6b531e7dbd2a56f1f306f37a80b1be9e00aa2d271690d08dcc5f326f71c9eed8546675c8caf6
+  languageName: node
+  linkType: hard
+
+"@protobufjs/codegen@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@protobufjs/codegen@npm:2.0.4"
+  checksum: 10c0/26ae337c5659e41f091606d16465bbcc1df1f37cc1ed462438b1f67be0c1e28dfb2ca9f294f39100c52161aef82edf758c95d6d75650a1ddf31f7ddee1440b43
+  languageName: node
+  linkType: hard
+
+"@protobufjs/eventemitter@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/eventemitter@npm:1.1.0"
+  checksum: 10c0/1eb0a75180e5206d1033e4138212a8c7089a3d418c6dfa5a6ce42e593a4ae2e5892c4ef7421f38092badba4040ea6a45f0928869989411001d8c1018ea9a6e70
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/fetch@npm:1.1.0"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.1"
+    "@protobufjs/inquire": "npm:^1.1.0"
+  checksum: 10c0/cda6a3dc2d50a182c5865b160f72077aac197046600091dbb005dd0a66db9cce3c5eaed6d470ac8ed49d7bcbeef6ee5f0bc288db5ff9a70cbd003e5909065233
+  languageName: node
+  linkType: hard
+
+"@protobufjs/float@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@protobufjs/float@npm:1.0.2"
+  checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+  languageName: node
+  linkType: hard
+
+"@protobufjs/inquire@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/inquire@npm:1.1.0"
+  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
+  languageName: node
+  linkType: hard
+
+"@protobufjs/path@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/path@npm:1.1.2"
+  checksum: 10c0/cece0a938e7f5dfd2fa03f8c14f2f1cf8b0d6e13ac7326ff4c96ea311effd5fb7ae0bba754fbf505312af2e38500250c90e68506b97c02360a43793d88a0d8b4
+  languageName: node
+  linkType: hard
+
+"@protobufjs/pool@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/pool@npm:1.1.0"
+  checksum: 10c0/eda2718b7f222ac6e6ad36f758a92ef90d26526026a19f4f17f668f45e0306a5bd734def3f48f51f8134ae0978b6262a5c517c08b115a551756d1a3aadfcf038
+  languageName: node
+  linkType: hard
+
+"@protobufjs/utf8@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/utf8@npm:1.1.0"
+  checksum: 10c0/a3fe31fe3fa29aa3349e2e04ee13dc170cc6af7c23d92ad49e3eeaf79b9766264544d3da824dba93b7855bd6a2982fb40032ef40693da98a136d835752beb487
+  languageName: node
+  linkType: hard
+
 "@rolldown/pluginutils@npm:1.0.0-beta.9":
   version: 1.0.0-beta.9
   resolution: "@rolldown/pluginutils@npm:1.0.0-beta.9"
@@ -1257,6 +1893,15 @@ __metadata:
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0":
+  version: 25.0.3
+  resolution: "@types/node@npm:25.0.3"
+  dependencies:
+    undici-types: "npm:~7.16.0"
+  checksum: 10c0/b7568f0d765d9469621615e2bb257c7fd1953d95e9acbdb58dffb6627a2c4150d405a4600aa1ad8a40182a94fe5f903cafd3c0a2f5132814debd0e3bfd61f835
   languageName: node
   linkType: hard
 
@@ -2240,6 +2885,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"faye-websocket@npm:0.11.4":
+  version: 0.11.4
+  resolution: "faye-websocket@npm:0.11.4"
+  dependencies:
+    websocket-driver: "npm:>=0.5.1"
+  checksum: 10c0/c6052a0bb322778ce9f89af92890f6f4ce00d5ec92418a35e5f4c6864a4fe736fec0bcebd47eac7c0f0e979b01530746b1c85c83cb04bae789271abf19737420
+  languageName: node
+  linkType: hard
+
 "fdir@npm:^6.4.4":
   version: 6.4.5
   resolution: "fdir@npm:6.4.5"
@@ -2284,6 +2938,42 @@ __metadata:
     locate-path: "npm:^6.0.0"
     path-exists: "npm:^4.0.0"
   checksum: 10c0/062c5a83a9c02f53cdd6d175a37ecf8f87ea5bbff1fdfb828f04bfa021441bc7583e8ebc0872a4c1baab96221fb8a8a275a19809fb93fbc40bd69ec35634069a
+  languageName: node
+  linkType: hard
+
+"firebase@npm:^12.7.0":
+  version: 12.7.0
+  resolution: "firebase@npm:12.7.0"
+  dependencies:
+    "@firebase/ai": "npm:2.6.1"
+    "@firebase/analytics": "npm:0.10.19"
+    "@firebase/analytics-compat": "npm:0.2.25"
+    "@firebase/app": "npm:0.14.6"
+    "@firebase/app-check": "npm:0.11.0"
+    "@firebase/app-check-compat": "npm:0.4.0"
+    "@firebase/app-compat": "npm:0.5.6"
+    "@firebase/app-types": "npm:0.9.3"
+    "@firebase/auth": "npm:1.12.0"
+    "@firebase/auth-compat": "npm:0.6.2"
+    "@firebase/data-connect": "npm:0.3.12"
+    "@firebase/database": "npm:1.1.0"
+    "@firebase/database-compat": "npm:2.1.0"
+    "@firebase/firestore": "npm:4.9.3"
+    "@firebase/firestore-compat": "npm:0.4.3"
+    "@firebase/functions": "npm:0.13.1"
+    "@firebase/functions-compat": "npm:0.4.1"
+    "@firebase/installations": "npm:0.6.19"
+    "@firebase/installations-compat": "npm:0.2.19"
+    "@firebase/messaging": "npm:0.12.23"
+    "@firebase/messaging-compat": "npm:0.2.23"
+    "@firebase/performance": "npm:0.7.9"
+    "@firebase/performance-compat": "npm:0.2.22"
+    "@firebase/remote-config": "npm:0.7.0"
+    "@firebase/remote-config-compat": "npm:0.2.20"
+    "@firebase/storage": "npm:0.14.0"
+    "@firebase/storage-compat": "npm:0.4.0"
+    "@firebase/util": "npm:1.13.0"
+  checksum: 10c0/1b23fd061bc7e7e4d5ac993fecd9f76622e7343bb1f7be367963014f1ea485f3deb3e4aa5bc3d198a8313339cf2a51adb8a5d4e9696fa9ed7c7752252438f132
   languageName: node
   linkType: hard
 
@@ -2576,6 +3266,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-parser-js@npm:>=0.5.1":
+  version: 0.5.10
+  resolution: "http-parser-js@npm:0.5.10"
+  checksum: 10c0/8bbcf1832a8d70b2bd515270112116333add88738a2cc05bfb94ba6bde3be4b33efee5611584113818d2bcf654fdc335b652503be5a6b4c0b95e46f214187d93
+  languageName: node
+  linkType: hard
+
 "http-proxy-agent@npm:^7.0.0":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
@@ -2602,6 +3299,13 @@ __metadata:
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10c0/98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
+  languageName: node
+  linkType: hard
+
+"idb@npm:7.1.1":
+  version: 7.1.1
+  resolution: "idb@npm:7.1.1"
+  checksum: 10c0/72418e4397638797ee2089f97b45fc29f937b830bc0eb4126f4a9889ecf10320ceacf3a177fe5d7ffaf6b4fe38b20bbd210151549bfdc881db8081eed41c870d
   languageName: node
   linkType: hard
 
@@ -2843,10 +3547,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.camelcase@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "lodash.camelcase@npm:4.3.0"
+  checksum: 10c0/fcba15d21a458076dd309fce6b1b4bf611d84a0ec252cb92447c948c533ac250b95d2e00955801ebc367e5af5ed288b996d75d37d2035260a937008e14eaf432
+  languageName: node
+  linkType: hard
+
 "lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: 10c0/402fa16a1edd7538de5b5903a90228aa48eb5533986ba7fa26606a49db2572bf414ff73a2c9f5d5fd36b31c46a5d5c7e1527749c07cbcf965ccff5fbdf32c506
+  languageName: node
+  linkType: hard
+
+"long@npm:^5.0.0":
+  version: 5.3.2
+  resolution: "long@npm:5.3.2"
+  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
   languageName: node
   linkType: hard
 
@@ -3342,6 +4060,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"protobufjs@npm:^7.2.5":
+  version: 7.5.4
+  resolution: "protobufjs@npm:7.5.4"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.2"
+    "@protobufjs/base64": "npm:^1.1.2"
+    "@protobufjs/codegen": "npm:^2.0.4"
+    "@protobufjs/eventemitter": "npm:^1.1.0"
+    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/float": "npm:^1.0.2"
+    "@protobufjs/inquire": "npm:^1.1.0"
+    "@protobufjs/path": "npm:^1.1.2"
+    "@protobufjs/pool": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.0"
+    "@types/node": "npm:>=13.7.0"
+    long: "npm:^5.0.0"
+  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
+  languageName: node
+  linkType: hard
+
 "proxy-from-env@npm:^1.1.0":
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
@@ -3608,6 +4346,13 @@ __metadata:
   dependencies:
     queue-microtask: "npm:^1.2.2"
   checksum: 10c0/200b5ab25b5b8b7113f9901bfe3afc347e19bb7475b267d55ad0eb86a62a46d77510cb0f232507c9e5d497ebda569a08a9867d0d14f57a82ad5564d991588b39
+  languageName: node
+  linkType: hard
+
+"safe-buffer@npm:>=5.1.0":
+  version: 5.2.1
+  resolution: "safe-buffer@npm:5.2.1"
+  checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
   languageName: node
   linkType: hard
 
@@ -3892,6 +4637,7 @@ __metadata:
     eslint: "npm:^9.25.0"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-react-refresh: "npm:^0.4.19"
+    firebase: "npm:^12.7.0"
     framer-motion: "npm:^12.16.0"
     globals: "npm:^16.0.0"
     notistack: "npm:^3.0.2"
@@ -3951,7 +4697,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.4.0":
+"tslib@npm:^2.1.0, tslib@npm:^2.4.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
@@ -3998,6 +4744,13 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.16.0":
+  version: 7.16.0
+  resolution: "undici-types@npm:7.16.0"
+  checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
   languageName: node
   linkType: hard
 
@@ -4113,6 +4866,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"web-vitals@npm:^4.2.4":
+  version: 4.2.4
+  resolution: "web-vitals@npm:4.2.4"
+  checksum: 10c0/383c9281d5b556bcd190fde3c823aeb005bb8cf82e62c75b47beb411014a4ed13fa5c5e0489ed0f1b8d501cd66b0bebcb8624c1a75750bd5df13e2a3b1b2d194
+  languageName: node
+  linkType: hard
+
+"websocket-driver@npm:>=0.5.1":
+  version: 0.7.4
+  resolution: "websocket-driver@npm:0.7.4"
+  dependencies:
+    http-parser-js: "npm:>=0.5.1"
+    safe-buffer: "npm:>=5.1.0"
+    websocket-extensions: "npm:>=0.1.1"
+  checksum: 10c0/5f09547912b27bdc57bac17b7b6527d8993aa4ac8a2d10588bb74aebaf785fdcf64fea034aae0c359b7adff2044dd66f3d03866e4685571f81b13e548f9021f1
+  languageName: node
+  linkType: hard
+
+"websocket-extensions@npm:>=0.1.1":
+  version: 0.1.4
+  resolution: "websocket-extensions@npm:0.1.4"
+  checksum: 10c0/bbc8c233388a0eb8a40786ee2e30d35935cacbfe26ab188b3e020987e85d519c2009fe07cfc37b7f718b85afdba7e54654c9153e6697301f72561bfe429177e0
+  languageName: node
+  linkType: hard
+
 "which@npm:^2.0.1":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
@@ -4206,7 +4984,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.5.1":
+"yargs@npm:^17.5.1, yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:


### PR DESCRIPTION
## Description

This PR lays the groundwork for the **reminder feature** while adding full **dueTime support** on the frontend.  

> Note: The reminder functionality is partially implemented — currently it obtains FCM token if the user allows notifications. Sending actual reminders can be implemented in the future.  

## Changes

### 1. Reminder setup
- When the user clicks the **reminder (clock) icon**, a prompt asks whether they allow notifications.  
- Integrated **Firebase Messaging**:  
  - Added project configuration.  
  - Set up `firebase-messaging-sw.js`.  
- Added `useReminder` hook to obtain FCM token if the user allows notifications.

### 2. Add dueTime support
- Added **DateTimePickerButton** component to handle **date and time selection** (previously only date).  
  - Includes **DateCalendar** and **TimePicker**.  
  - Generates **valid time options** based on current time (e.g., if now is 9:42, options start from 9:45, 10:00,..., every 15 minutes).  
- Added helper functions:  
  - `formatVnTime` — formats time for display.  
  - `isTaskExpired` — checks if a task is past due.  
- Adjusted frontend data types to match backend

### 3. Refactor and helpers
- Separated date/time logic from parent component into **DateTimePickerButton** for cleaner code and reusability.  
- Added validation to prevent selecting past times.  

## Notes
- Reminder sending is **not yet implemented** — this PR only sets up FCM integration and permission handling.  
- Future work can use `useReminder` and the stored FCM token to schedule reminders.